### PR TITLE
fix: return fresh data on form redirect

### DIFF
--- a/app/create-recipe/page.tsx
+++ b/app/create-recipe/page.tsx
@@ -2,10 +2,11 @@
 import { useTransition } from 'react';
 import { RecipeForm } from '@/components/recipe-edit-form.client';
 import { formSubmitAction } from '@/app/actions/form-submit';
-import { redirect } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 
 const CreateRecipe = () => {
   const [, startTransition] = useTransition();
+  const router = useRouter();
   return (
     <div>
       <h1 className='text-3xl text-center mt-2'>Add a Recipe</h1>
@@ -14,7 +15,7 @@ const CreateRecipe = () => {
           startTransition(async () => {
             const result = await formSubmitAction(data);
             if (result?.[0]?.recipeId) {
-              redirect(`/recipes/${result[0].recipeId}`);
+              router.push(`/recipes/${result[0].recipeId}`);
             }
           });
         }}

--- a/app/edit-recipe/[slug]/edit-recipe.client.tsx
+++ b/app/edit-recipe/[slug]/edit-recipe.client.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { redirect } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import { useTransition } from 'react';
 import { RecipeForm } from '@/components/recipe-edit-form.client';
 import { recipeUpdateAction } from '@/app/actions/form-submit';
@@ -12,6 +12,7 @@ interface EditRecipeProps {
 
 export const EditRecipe = ({ recipe }: EditRecipeProps) => {
   const [, startTransition] = useTransition();
+  const router = useRouter();
   const { id, ...recipeData } = recipe;
   return (
     <div>
@@ -23,7 +24,7 @@ export const EditRecipe = ({ recipe }: EditRecipeProps) => {
             if (Object.keys(updatedFields).length !== 0) {
               await recipeUpdateAction(updatedFields, id);
             }
-            redirect(`/recipes/${id}`);
+            router.push(`/recipes/${id}`);
           });
         }}
         onSubmitError={(error) => {


### PR DESCRIPTION
closes #38 
fixes a bug where new recipes were 404s until manually refreshed

### What I Did

- replaces `redirect` with `router.push`