### PR TITLE
fix: fix crash on recipe edit bug

### DIFF
--- a/app/actions/form-actions.ts
+++ b/app/actions/form-actions.ts
@@ -117,8 +117,10 @@ export const recipeUpdateAction = async (
       data.instructions = sanitizeHtml(data.instructions);
     }
     console.log(`updating recipe ${id} with data: \n`);
+    console.log(data);
     if (!dryRun) {
-      return db.updateRecipe(id, { ...data, imageUrl: undefined });
+      await db.updateRecipe(id, { ...data, imageUrl: undefined });
+      return;
     }
     console.log('skipping database update because this is a dry run...');
   } finally {


### PR DESCRIPTION
### What I Did

The recipe edit route was successfully editing recipes but then crashing before redirecting. This seems to have been because it was returning something that can't be returned from a server action to a client component. The client component actually ignores the return value so the easy fix is to just not return it.