### PR TITLE
Remove edit caching

### DIFF
--- a/app/edit-recipe/[slug]/page.tsx
+++ b/app/edit-recipe/[slug]/page.tsx
@@ -1,9 +1,11 @@
 import { notFound } from 'next/navigation';
 import { loadRecipe } from '@/app/actions/load-recipe';
 import { EditRecipe } from './edit-recipe.client';
+import { unstable_noStore as noStore } from 'next/cache';
 import { Suspense } from 'react';
 
 const Page = async ({ params }: { params: { slug: string } }) => {
+  noStore();
   const { slug } = params;
   const recipeId = parseInt(slug);
   if (Number.isNaN(recipeId)) {

--- a/app/recipes/[slug]/page.tsx
+++ b/app/recipes/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { currentUser } from '@clerk/nextjs/server';
 import { hasElevatedPermissions } from '@/lib/auth';
 import { LinkButton } from '@/components/recipe-gallery/link-button.client';
 import { ClockIcon } from '@radix-ui/react-icons';
+import { images } from '@/lib/constants';
 
 const Page = async ({ params }: { params: { slug: string } }) => {
   const { slug } = params;
@@ -29,6 +30,7 @@ const Page = async ({ params }: { params: { slug: string } }) => {
             <LinkButton href={`/edit-recipe/${recipeId}`}>Edit</LinkButton>
           ) : null}
         </span>
+        <p className='italic mt-0 mb-[2.5em]'>{recipe.description}</p>
         {recipe.author ? <p>By {recipe.author}</p> : null}
         {recipe.recipeTime ? (
           <span className='flex flex-row gap-2 items-baseline'>
@@ -36,16 +38,14 @@ const Page = async ({ params }: { params: { slug: string } }) => {
             {recipe.recipeTime}
           </span>
         ) : null}
-        {recipe.imageUrl ? (
-          <div className='relative w-[calc(100%+2rem)] pb-[calc(56.25%+1.125rem)] -mx-4'>
-            <Image
-              src={recipe.imageUrl}
-              alt={recipe.title}
-              fill
-              className='object-cover'
-            />
-          </div>
-        ) : null}
+        <div className='relative w-[calc(100%+2rem)] pb-[calc(56.25%+1.125rem)] -mx-4'>
+          <Image
+            src={recipe.imageUrl ?? images.default}
+            alt={recipe.title}
+            fill
+            className='object-cover'
+          />
+        </div>
         {/* HTML here is sanitized on the server-side and should be safe to set */}
         <div dangerouslySetInnerHTML={{ __html: recipe.instructions }} />
       </div>


### PR DESCRIPTION
Thank you for contributing to the [grits greenbeans and grandmothers website](https://gritsgreenbeansandgrandmothers.com).

There isn't currently much of a process for contribution. But it would be helpful if you write a brief summary of what your pull request does.

### What I Did

- Removes caching for recipe edit page. It's important this information is always up to date or people could accidentally overwrite new data with cached data.
- Updates recipe formatting to include description and use fallback image when no image exists.