### PR TITLE
Card redesign

### DIFF
--- a/components/recipe-gallery/recipe-card.client.tsx
+++ b/components/recipe-gallery/recipe-card.client.tsx
@@ -30,7 +30,7 @@ export const RecipeCardDesign = (props: RecipeCardDesignProps) => {
       className='flex flex-col md:flex-row w-full h-full max-4-4xl cursor-pointer'
       onClick={props.onClick}
     >
-      <div className='md:w-1/2 overflow-hidden rounded-t-lg md:rounded-t-none md:rounded-l-lg'>
+      <div className='h-2/5 md:h-auto md:w-2/5 overflow-hidden rounded-t-lg md:rounded-t-none md:rounded-l-lg'>
         <Image
           src={props.imageUrl || images.default}
           placeholder='blur'
@@ -41,17 +41,23 @@ export const RecipeCardDesign = (props: RecipeCardDesignProps) => {
           className='w-full h-full object-cover'
         />
       </div>
-      <div className='p-6 md:p-8 flex flex-col justify-center'>
-        <CardTitle id={titleId} className='text-lg'>
+      <div className='h-3/5 md:h-auto p-6 md:p-8 md:w-3/5 flex flex-col justify-between md:justify-center'>
+        <CardTitle id={titleId} className='text-lg md:text-2xl'>
           {props.title}
         </CardTitle>
         {props.author ? (
-          <p className='mt-4 mb-3 text-zinc-700 text-sm'>
-            Author: {props.author}
+          <p className='mt-4 mb-3 text-zinc-700 text-sm md:text-lg'>
+            {props.author}
           </p>
         ) : undefined}
-        <CardDescription className='mt-2 text-zinc-500' id={descriptionId}>
-          {props.description}
+        <CardDescription className='mt-2 text-zinc-500 flex-grow md:flex-none overflow-hidden'>
+          <div
+            className='line-clamp-4'
+            id={descriptionId}
+            title={props.description}
+          >
+            {props.description}
+          </div>
         </CardDescription>
         <div className='mt-6 flex gap-2'>
           <LinkButton

--- a/components/recipe-gallery/recipe-card.client.tsx
+++ b/components/recipe-gallery/recipe-card.client.tsx
@@ -17,16 +17,18 @@ export interface RecipeCardProps {
   author?: string | null;
 }
 
-export const RecipeCard = (props: RecipeCardProps) => {
+export interface RecipeCardDesignProps extends RecipeCardProps {
+  onClick?: () => void;
+  linkDisabled?: boolean; // for storybook
+}
+
+export const RecipeCardDesign = (props: RecipeCardDesignProps) => {
   const titleId = useId();
   const descriptionId = useId();
-  const router = useRouter();
   return (
     <Card
       className='flex flex-col md:flex-row w-full h-full max-4-4xl cursor-pointer'
-      onClick={() => {
-        router.push(props.href);
-      }}
+      onClick={props.onClick}
     >
       <div className='md:w-1/2 overflow-hidden rounded-t-lg md:rounded-t-none md:rounded-l-lg'>
         <Image
@@ -56,6 +58,7 @@ export const RecipeCard = (props: RecipeCardProps) => {
             href={props.href}
             aria-labelledby={titleId}
             aria-describedby={descriptionId}
+            disabled={props.linkDisabled}
           >
             Read More
           </LinkButton>
@@ -63,4 +66,10 @@ export const RecipeCard = (props: RecipeCardProps) => {
       </div>
     </Card>
   );
+};
+
+export const RecipeCard = (props: RecipeCardProps) => {
+  const router = useRouter();
+  const onClick = () => router.push(props.href);
+  return <RecipeCardDesign onClick={onClick} {...props} />;
 };

--- a/components/recipe-gallery/recipe-gallery.tsx
+++ b/components/recipe-gallery/recipe-gallery.tsx
@@ -52,7 +52,10 @@ const RecipeGallery = async ({
         {recipes.map((recipe) => {
           const { id, ...recipeProps } = recipe;
           return (
-            <li key={recipeProps.title} className='col-span-7 col-start-2 h-96'>
+            <li
+              key={recipeProps.title}
+              className='col-span-7 col-start-2 h-[28rem]'
+            >
               <RecipeCard {...recipeProps} href={`/recipes/${id}`} />
             </li>
           );

--- a/stories/recipe-card.stories.ts
+++ b/stories/recipe-card.stories.ts
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { RecipeCardDesign } from '@/components/recipe-gallery/recipe-card.client';
+import { images } from '@/lib/constants';
+
+const meta = {
+  title: 'Example/RecipeCard',
+  component: RecipeCardDesign,
+} satisfies Meta<typeof RecipeCardDesign>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const ShortDescription: Story = {
+  args: {
+    title: 'Example Card',
+    description: 'This card has a short description',
+    href: '',
+    imageUrl: images.grits,
+    author: 'grandmother_bot',
+    linkDisabled: true,
+    onClick: () => {
+      console.log('card clicked');
+    },
+  },
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: '/recipes',
+      },
+    },
+  },
+};
+
+export const LongDescription: Story = {
+  args: {
+    title: 'Card with long description',
+    description:
+      'The pasta was smooth and practical, the fruit was sweet and carefree. They knew it was a scandalous match, but they couldn’t help themselves! They eloped right then and there, and now, here they are—living their best, rebellious life in this salad.',
+    href: '',
+    imageUrl: images.grits,
+    author: 'grandmother_bot',
+    linkDisabled: true,
+    onClick: () => {
+      console.log('card clicked');
+    },
+  },
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: '/recipes',
+      },
+    },
+  },
+};


### PR DESCRIPTION
### What I Did

Closes #78 

- Changes the cards so that the image takes up 40% of the card's main axis and the text takes up 60%.
- Makes some other adjustments to make it so that this continues to work well with different recipe description sizes
- Truncates descriptions that get too long and add a tooltip for them
