### PR TITLE
make grandmother_bot remember chat history

### DIFF
--- a/components/grandmother-bot/config/adapters.ts
+++ b/components/grandmother-bot/config/adapters.ts
@@ -1,14 +1,20 @@
 import { useAsStreamAdapter, type StreamingAdapterObserver } from '@nlux/react';
 import { createPromptFromContext } from './prompts';
 import '@nlux/themes/nova.css';
+import { convertNluxChatHistory } from '@/lib/translation/parsers';
 
 export const useChatAdapter = (context?: string) => {
   return useAsStreamAdapter(
-    async (prompt: string, observer: StreamingAdapterObserver) => {
+    async (
+      prompt: string,
+      observer: StreamingAdapterObserver,
+      { conversationHistory }
+    ) => {
       const response = await fetch('/api/chat', {
         method: 'POST',
         body: JSON.stringify({
           prompt: createPromptFromContext(prompt, context),
+          history: convertNluxChatHistory(conversationHistory),
         }),
         headers: { 'Content-Type': 'application/json' },
       });

--- a/lib/translation/parsers.ts
+++ b/lib/translation/parsers.ts
@@ -1,3 +1,5 @@
+import type { CoreMessage } from 'ai';
+import type { ChatItem } from '@nlux/react';
 import { IMAGE_BASE_URL } from '../constants';
 import {
   intermediateSchema,
@@ -95,4 +97,18 @@ ${time}
 ${indentedInstructions}
 </div>`;
   return output;
+};
+
+// The docs for the library I'm using are not clear on this but it seems like chatHistory can contain string arrays
+// I'm guessing this is because the message was streamed in chunks and this is how they're represented, but I'm not
+// totally sure. We need to converte these chunks into a single string when this happens.
+export const convertNluxChatHistory = (
+  chatHistory?: ChatItem<string | string[]>[]
+): CoreMessage[] => {
+  return (
+    chatHistory?.map(({ role, message }) => ({
+      role,
+      content: Array.isArray(message) ? message.join('') : message,
+    })) ?? []
+  );
 };


### PR DESCRIPTION
### What I Did

grandmother_bot no longer has amnesia!

- adds chat history to open ai api calls
- limits chat history to 10 to avoid sending an excessive amount of tokens