### PR TITLE
fix: pass category to searchParams parser

### DIFF
--- a/components/recipe-gallery/recipe-gallery.tsx
+++ b/components/recipe-gallery/recipe-gallery.tsx
@@ -31,7 +31,7 @@ export const createSearchParamProps = (searchParams: NextSearchParams) => {
   // Zod will return undefined if there are extra search params values and we parse them directly
   // I'd rather just ignore these params and handle valid params correctly whenever present
   const { page, query, category } = searchParams;
-  const { data } = searchParamsSchema.safeParse({ page, query });
+  const { data } = searchParamsSchema.safeParse({ page, query, category });
   return {
     page: data?.page ?? 1,
     filter: data?.query,


### PR DESCRIPTION
Thank you for contributing to the [grits greenbeans and grandmothers website](https://gritsgreenbeansandgrandmothers.com).

There isn't currently much of a process for contribution. But it would be helpful if you write a brief summary of what your pull request does.

### What I Did

I forgot to pass catagory to the search params schema parser so it was falling back to title.
