### PR TITLE
add admin area for one-off global cache invalidations

### DIFF
--- a/app/admin/admin-action-button.tsx
+++ b/app/admin/admin-action-button.tsx
@@ -1,0 +1,28 @@
+'use client';
+import { Button } from '@/components/ui/button';
+import { ReactNode, useState } from 'react';
+
+interface AdminActionButtonProps {
+  adminAction: () => Promise<void>;
+  children?: ReactNode;
+}
+
+export const AdminActionButton = ({
+  adminAction,
+  children,
+}: AdminActionButtonProps) => {
+  const [log, setLog] = useState<string>();
+  return (
+    <form action={adminAction}>
+      <Button
+        type='submit'
+        onClick={() => {
+          setLog('queued action. check server logs for details.');
+        }}
+      >
+        {children}
+      </Button>
+      {log && <p>Log: {log}</p>}
+    </form>
+  );
+};

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,43 @@
+import { notFound } from 'next/navigation';
+import { currentUser } from '@clerk/nextjs/server';
+import { hasAdminPermissions } from '@/lib/auth';
+import { z } from 'zod';
+import { getRecipes } from '@/lib/repository/recipe-store/read';
+import { revalidatePath } from 'next/cache';
+import { AdminActionButton } from './admin-action-button';
+
+const invalidationSchema = z.array(
+  z.object({
+    id: z.number(),
+    title: z.string(),
+  })
+);
+
+const inavalidateAllCachesAction = async () => {
+  'use server';
+  const result = await getRecipes({ keys: ['id', 'title'] });
+  const rows = invalidationSchema.parse(result);
+  for (const { id, title } of rows) {
+    console.log(`admin: invalidating cache for ${title} page`);
+    revalidatePath(`/recipes/${id}`);
+  }
+  console.log('admin: finished revalidating paths');
+};
+
+const AdminStuff = async () => {
+  const user = await currentUser();
+  if (!hasAdminPermissions(user)) {
+    return notFound();
+  }
+
+  return (
+    <div className='m-auto prose prose-zinc'>
+      <h1>Admin Stuff</h1>
+      <AdminActionButton adminAction={inavalidateAllCachesAction}>
+        Invalidate All Caches
+      </AdminActionButton>
+    </div>
+  );
+};
+
+export default AdminStuff;


### PR DESCRIPTION
closes #101 

### What I Did

Certain tags weren't showing up on recipes. When I looked into why this is it seems like is a caching issue:

When recipes are edited, the cache for the edited recipe pages needs to be revalidated. When it is not, the tags never show up because the stale page is sent instead.

This is something I already added to recipe edits a while back. The issue now is that if a recipe was last edited *before* this bug was fixed, those edits will never show up without a new edit.

This change adds an admin page with a button to invalidate all caches. This will allow the caches to be reset and prevent pages from being stale. Since cache revalidation is built in to edits now this should not be necessary more than once unless another mistake is made further down the road.