### PR TITLE
fix: use tagId in join in getRecipeCountFilteredByTags

### DIFF
--- a/lib/actions/load-page-count.ts
+++ b/lib/actions/load-page-count.ts
@@ -18,7 +18,9 @@ export const loadPageCountAction = async ({
 }: LoadPageCountArgs) => {
   const [{ count }] = await getRecipeCount(filter, category);
   if (debug) {
-    console.log(`Got page count ${count}`);
+    console.log(
+      `Got item count ${count} and page count ${Math.ceil(count / pageSize)}`
+    );
   }
   return Math.ceil(count / pageSize);
 };

--- a/lib/repository/recipe-store/read.ts
+++ b/lib/repository/recipe-store/read.ts
@@ -164,7 +164,7 @@ const getRecipeCountFilteredByTags = (searchString?: string) => {
     .select({ count: countDistinct(recipes.id) })
     .from(recipesToTags)
     .leftJoin(recipes, eq(recipes.id, recipesToTags.recipeId))
-    .leftJoin(tags, eq(tags.id, recipesToTags.id))
+    .leftJoin(tags, eq(tags.id, recipesToTags.tagId))
     .where(like(tags.name, `%${searchString}%`));
 };
 


### PR DESCRIPTION
Thank you for contributing to the [grits greenbeans and grandmothers website](https://gritsgreenbeansandgrandmothers.com).

There isn't currently much of a process for contribution. But it would be helpful if you write a brief summary of what your pull request does.

### What I Did

closes #107

The page count for tag search was coming out wrong. This is because I did the join for the tags table incorrectly.