### PR TITLE
refactor: turn unnecessary server actions into loader functions

### DIFF
--- a/__mocks__/loadRecipes.ts
+++ b/__mocks__/loadRecipes.ts
@@ -1,10 +1,7 @@
 'use server';
 
 import { images } from '@/lib/constants';
-import type {
-  LoadRecipeAction,
-  LoadPageCountAction,
-} from '@/components/recipe-gallery';
+import type { LoadRecipes, LoadPageCount } from '@/components/recipe-gallery';
 
 const createDummyRecipes = (count: number) => {
   return [...Array(count)].map((_, i) => ({
@@ -27,7 +24,7 @@ const makeFilter =
   ({ title }: DatabaseEntry) =>
     title[func](filterValue);
 
-export const mockLoadRecipeAction: LoadRecipeAction = async ({
+export const mockLoadRecipes: LoadRecipes = async ({
   page = 0,
   pageSize = 10,
   filter,
@@ -46,8 +43,5 @@ export const mockLoadRecipeAction: LoadRecipeAction = async ({
     .slice(page * pageSize, (page + 1) * pageSize);
 };
 
-export const mockLoadPageCountAction: LoadPageCountAction = async ({
-  filter,
-  pageSize,
-}) =>
+export const mockLoadPageCount: LoadPageCount = async ({ filter, pageSize }) =>
   Math.ceil(mockDatabase.filter(makeFilter(filter ?? '')).length / pageSize);

--- a/app/edit-recipe/[slug]/page.tsx
+++ b/app/edit-recipe/[slug]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from 'next/navigation';
 import { EditRecipe } from './edit-recipe.client';
 import { unstable_noStore as noStore } from 'next/cache';
 import { Suspense } from 'react';
-import { loadRecipeFormAction } from '@/lib/actions/load-edit-page';
+import { loadRecipeForm } from '@/lib/loaders/load-recipe-form';
 
 const Page = async ({ params }: { params: { slug: string } }) => {
   noStore();
@@ -12,7 +12,7 @@ const Page = async ({ params }: { params: { slug: string } }) => {
     return notFound();
   }
 
-  const result = await loadRecipeFormAction(recipeId);
+  const result = await loadRecipeForm(recipeId);
   if (result === undefined) {
     return notFound();
   }

--- a/app/recipes/[slug]/page.tsx
+++ b/app/recipes/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from 'next/navigation';
 import Image from 'next/image';
-import { loadRecipePageAction } from '@/lib/actions/load-recipe-page';
+import { loadRecipePage } from '@/lib/loaders/load-recipe-page';
 import { currentUser } from '@clerk/nextjs/server';
 import { hasElevatedPermissions } from '@/lib/auth';
 import { DecorativeTag as Tag } from '@/components/form/decorative-tag';
@@ -18,7 +18,7 @@ const Page = async ({ params }: { params: { slug: string } }) => {
     return notFound();
   }
 
-  const recipe = await loadRecipePageAction(recipeId);
+  const recipe = await loadRecipePage(recipeId);
   if (recipe === undefined) {
     return notFound();
   }

--- a/components/recipe-gallery/recipe-gallery.tsx
+++ b/components/recipe-gallery/recipe-gallery.tsx
@@ -8,17 +8,17 @@ import {
 import { cn } from '@/lib/utils';
 import { Suspense } from 'react';
 import { unstable_noStore as noStore } from 'next/cache';
-import { loadGalleryPageAction } from '@/lib/actions/load-gallery-page';
-import { loadPageCountAction as defaultLoadPageCountAction } from '@/lib/actions/load-page-count';
+import { loadGalleryPage } from '@/lib/loaders/load-gallery-page';
+import { loadPageCount as defaultLoadPageCount } from '@/lib/loaders/load-page-count';
 
-export type LoadRecipeAction = typeof loadGalleryPageAction;
+export type LoadRecipes = typeof loadGalleryPage;
 
-export type LoadPageCountAction = typeof defaultLoadPageCountAction;
+export type LoadPageCount = typeof defaultLoadPageCount;
 
 export interface RecipeGalleryProps {
   page: number;
-  loadRecipeAction?: LoadRecipeAction;
-  loadPageCountAction?: LoadPageCountAction;
+  loadRecipes?: LoadRecipes;
+  loadPageCount?: LoadPageCount;
   pageSize?: number;
   className?: string;
   filter?: string;
@@ -44,14 +44,14 @@ const RecipeGallery = async ({
   pageSize = defaultPageSize,
   filter,
   category,
-  loadPageCountAction = defaultLoadPageCountAction,
-  loadRecipeAction = loadGalleryPageAction,
+  loadPageCount = defaultLoadPageCount,
+  loadRecipes = loadGalleryPage,
   ...props
 }: RecipeGalleryProps) => {
   // TODO: improve on this by being more granular with caching strategy
   noStore();
-  const pageCount = await loadPageCountAction({ pageSize, filter, category });
-  const recipes = await loadRecipeAction({ page, pageSize, filter, category });
+  const pageCount = await loadPageCount({ pageSize, filter, category });
+  const recipes = await loadRecipes({ page, pageSize, filter, category });
   return (
     <Suspense fallback={<p>Loading...</p>}>
       <ul className={cn('w-full grid grid-cols-9 gap-4', props.className)}>

--- a/lib/actions/ai/recipe-chat/index.ts
+++ b/lib/actions/ai/recipe-chat/index.ts
@@ -23,7 +23,7 @@ const classifyPrompt = async (messages: CoreMessage[]) => {
     output: 'object',
     schema: z.object({ calculation: z.boolean() }),
     system: classifierSystemMessage,
-    messages: messages,
+    messages,
   });
 
   return calculation;

--- a/lib/loaders/load-gallery-page.ts
+++ b/lib/loaders/load-gallery-page.ts
@@ -1,5 +1,3 @@
-'use server';
-
 import { galleryItemSchema, SearchCategory } from '@/lib/translation/schema';
 import {
   createPaginateClause,
@@ -19,7 +17,7 @@ export interface LoadGalleryArgs {
   debug?: boolean;
 }
 
-export const loadGalleryPageAction = async ({
+export const loadGalleryPage = async ({
   page,
   pageSize,
   filter,

--- a/lib/loaders/load-page-count.ts
+++ b/lib/loaders/load-page-count.ts
@@ -1,5 +1,3 @@
-'use server';
-
 import { SearchCategory } from '@/lib/translation/schema';
 import { getRecipeCount } from '@/lib/repository/recipe-store/read';
 
@@ -10,7 +8,7 @@ export interface LoadPageCountArgs {
   debug?: boolean;
 }
 
-export const loadPageCountAction = async ({
+export const loadPageCount = async ({
   pageSize,
   filter,
   category,

--- a/lib/loaders/load-recipe-form.ts
+++ b/lib/loaders/load-recipe-form.ts
@@ -1,11 +1,9 @@
-'use server';
-
 import { getRecipes } from '@/lib/repository/recipe-store/read';
 import { createWhereIdClause } from '@/lib/repository/recipe-store/utils';
 import { recipePageSchema } from '@/lib/translation/schema';
 import { convertPageToForm } from '@/lib/translation/parsers';
 
-export const loadRecipeFormAction = async (recipeId: number) => {
+export const loadRecipeForm = async (recipeId: number) => {
   const recipes = await getRecipes({
     keys: [
       'title',

--- a/lib/loaders/load-recipe-page.ts
+++ b/lib/loaders/load-recipe-page.ts
@@ -1,9 +1,8 @@
-'use server';
 import { getRecipes } from '@/lib/repository/recipe-store/read';
 import { createWhereIdClause } from '@/lib/repository/recipe-store/utils';
 import { recipePageSchema } from '@/lib/translation/schema';
 
-export const loadRecipePageAction = async (recipeId: number) => {
+export const loadRecipePage = async (recipeId: number) => {
   const recipes = await getRecipes({
     keys: [
       'title',


### PR DESCRIPTION
### What I Did

I got too excited about server actions and used them places where it didn't make sense to.

Any data fetching that happens within a server component is done more efficiently if it just gets called in the component directly instead of adding an extra layer of indirection with a server action.

I introduced `/lib/loaders` for this use case and moved server actions that didn't need to be called from the client to loaders.