### PR TITLE
feat: SEO baseline (robots, sitemap, metadata)

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import type { Metadata } from 'next';
 import { FamilyOnly } from '@/components/auth/family-only';
 import {
   FAMILY_TREE_LINK,
@@ -6,6 +7,20 @@ import {
   GITHUB_REPO_LINK,
 } from '@/lib/constants';
 import { EmailIcon } from '@/components/icons';
+
+const ABOUT_DESCRIPTION =
+  'The story behind our family recipe collection — Ada Wesson Jones’s 1994 introduction, the cooks who came before us, and the cookbook this site continues.';
+
+export const metadata: Metadata = {
+  title: 'About',
+  description: ABOUT_DESCRIPTION,
+  openGraph: {
+    title: 'About',
+    description: ABOUT_DESCRIPTION,
+    url: '/about',
+    type: 'article',
+  },
+};
 
 const AboutPage = () => {
   return (

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { currentUser } from '@clerk/nextjs/server';
 import { hasAdminPermissions } from '@/lib/auth';
@@ -22,6 +23,10 @@ const inavalidateAllCachesAction = async () => {
     revalidatePath(`/recipes/${id}`);
   }
   console.log('admin: finished revalidating paths');
+};
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
 };
 
 const AdminStuff = async () => {

--- a/app/create-recipe/layout.tsx
+++ b/app/create-recipe/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
+
+export default function CreateRecipeLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/delete-my-account/page.tsx
+++ b/app/delete-my-account/page.tsx
@@ -1,3 +1,9 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
+
 const DeleteMyAccount = () => (
   <div className='prose prose-zinc rendered-recipe bg-white mx-auto px-6 min-h-full -mt-4 pt-4 border-x border-zinc-200'>
     <h1>How to delete your account</h1>

--- a/app/edit-recipe/[slug]/page.tsx
+++ b/app/edit-recipe/[slug]/page.tsx
@@ -1,8 +1,13 @@
+import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { EditRecipe } from './edit-recipe.client';
 import { unstable_noStore as noStore } from 'next/cache';
 import { Suspense } from 'react';
 import { loadRecipeForm } from '@/lib/loaders/load-recipe-form';
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
 
 const Page = async ({ params }: { params: { slug: string } }) => {
   noStore();

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,14 +2,41 @@ import { ClerkProvider } from '@clerk/nextjs';
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import Navbar from '@/components/navbar';
+import { SITE_URL } from '@/lib/constants';
 import { cn } from '@/lib/utils';
 import './globals.css';
 
 const inter = Inter({ subsets: ['latin'] });
 
+const SITE_NAME = 'Grits Greenbeans and Grandmothers';
+const SITE_DESCRIPTION =
+  'Heritage Southern recipes passed down through generations of our family — from a 1994 family cookbook to your kitchen today.';
+
 export const metadata: Metadata = {
-  title: 'Grits Greenbeans and Grandmothers',
-  description: 'A site for family recipes',
+  metadataBase: new URL(SITE_URL),
+  title: {
+    default: SITE_NAME,
+    template: `%s — ${SITE_NAME}`,
+  },
+  description: SITE_DESCRIPTION,
+  applicationName: SITE_NAME,
+  openGraph: {
+    type: 'website',
+    siteName: SITE_NAME,
+    title: SITE_NAME,
+    description: SITE_DESCRIPTION,
+    url: SITE_URL,
+    locale: 'en_US',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: SITE_NAME,
+    description: SITE_DESCRIPTION,
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
 };
 
 export default function RootLayout({

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,7 +29,7 @@ export const metadata: Metadata = {
     locale: 'en_US',
   },
   twitter: {
-    card: 'summary_large_image',
+    card: 'summary',
     title: SITE_NAME,
     description: SITE_DESCRIPTION,
   },

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,19 @@
+import type { MetadataRoute } from 'next';
+import { SITE_URL } from '@/lib/constants';
+
+const robots = (): MetadataRoute.Robots => ({
+  rules: {
+    userAgent: '*',
+    allow: '/',
+    disallow: [
+      '/admin',
+      '/create-recipe',
+      '/edit-recipe/',
+      '/delete-my-account',
+    ],
+  },
+  sitemap: `${SITE_URL}/sitemap.xml`,
+  host: SITE_URL,
+});
+
+export default robots;

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,31 @@
+import type { MetadataRoute } from 'next';
+import { SITE_URL } from '@/lib/constants';
+
+const sitemap = async (): Promise<MetadataRoute.Sitemap> => {
+  const now = new Date();
+
+  return [
+    {
+      url: `${SITE_URL}/`,
+      lastModified: now,
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: `${SITE_URL}/about`,
+      lastModified: now,
+      changeFrequency: 'yearly',
+      priority: 0.5,
+    },
+    // When the site goes public, append entries for each recipe here, e.g.:
+    //   const recipes = await loadAllRecipeSlugs();
+    //   ...recipes.map((r) => ({
+    //     url: `${SITE_URL}/recipes/${r.slug}`,
+    //     lastModified: r.updatedAt,
+    //     changeFrequency: 'yearly' as const,
+    //     priority: 0.8,
+    //   })),
+  ];
+};
+
+export default sitemap;

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -9,6 +9,8 @@ export const images = {
     'https://grits-greenbeans-and-grandmothers.s3.us-east-005.backblazeb2.com/images/default_recipe_image_00.png',
 };
 
+export const SITE_URL = 'https://gritsgreenbeansandgrandmothers.com';
+
 export const FAMILY_TREE_LINK = process.env.family_tree_link ?? '';
 export const EMAIL_ADDRESS = process.env.email_address ?? '';
 export const GITHUB_REPO_LINK =

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -9,7 +9,11 @@ export const images = {
     'https://grits-greenbeans-and-grandmothers.s3.us-east-005.backblazeb2.com/images/default_recipe_image_00.png',
 };
 
-export const SITE_URL = 'https://gritsgreenbeansandgrandmothers.com';
+const stripTrailingSlash = (url: string) => url.replace(/\/+$/, '');
+
+export const SITE_URL = stripTrailingSlash(
+  process.env.SITE_URL ?? 'https://gritsgreenbeansandgrandmothers.com',
+);
 
 export const FAMILY_TREE_LINK = process.env.family_tree_link ?? '';
 export const EMAIL_ADDRESS = process.env.email_address ?? '';

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -12,7 +12,7 @@ export const images = {
 const stripTrailingSlash = (url: string) => url.replace(/\/+$/, '');
 
 export const SITE_URL = stripTrailingSlash(
-  process.env.SITE_URL ?? 'https://gritsgreenbeansandgrandmothers.com',
+  process.env.SITE_URL ?? 'https://gritsgreenbeansandgrandmothers.com'
 );
 
 export const FAMILY_TREE_LINK = process.env.family_tree_link ?? '';


### PR DESCRIPTION
## Summary
- Add `app/robots.ts` allowing crawl of public routes, disallowing `/admin`, `/create-recipe`, `/edit-recipe/`, `/delete-my-account`, and pointing to the sitemap.
- Add `app/sitemap.ts` listing the home and About pages today, with a labeled placeholder for the recipe loop once the site goes public.
- Expand site-wide metadata in `app/layout.tsx`: `metadataBase`, `title.template`, richer description, Open Graph + Twitter cards, explicit `robots` directive.
- Add per-page `metadata` to `app/about/page.tsx` as the working example for the pattern recipe pages will adopt later.
- Add `SITE_URL` constant to `lib/constants.ts` so the production domain lives in one place.

## Out of scope (deliberate)
- Recipe JSON-LD schema, per-recipe `generateMetadata`, and slug-based URLs all need a small data-model conversation first (instructions are currently a freeform HTML blob).
- No OG image yet — needs a branding decision.
- No favicon yet — needs an icon asset.

## Test plan
- [ ] `bun run dev` and visit `/robots.txt` — confirm Allow/Disallow rules and sitemap line.
- [ ] Visit `/sitemap.xml` — confirm two `<url>` entries (home + about) using the production domain.
- [ ] Visit `/` and `/about`, view source, confirm `<title>`, `<meta name="description">`, and `og:*` / `twitter:*` tags are present and About-specific on `/about`.
- [ ] Browser tab on `/about` reads "About — Grits Greenbeans and Grandmothers".
- [ ] After deploy, paste a production URL into opengraph.xyz / Facebook Sharing Debugger and confirm preview card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)