### PR TITLE
SEO-friendly recipe slugs with canonical redirect and metadata

### DIFF
--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -24,4 +24,4 @@ jobs:
 
       - name: Run lib unit tests
         id: bun-test-lib
-        run: find lib \( -name '*.test.ts' -o -name '*.test.tsx' \) | sed 's|^|./|' | xargs bun test
+        run: find lib \( -name '*.test.ts' -o -name '*.test.tsx' \) -exec printf './%s\0' {} + | xargs -0 -r bun test

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -21,3 +21,7 @@ jobs:
       - name: Run component unit tests
         id: bun-test-client
         run: bun test
+
+      - name: Run lib unit tests
+        id: bun-test-lib
+        run: find lib \( -name '*.test.ts' -o -name '*.test.tsx' \) | sed 's|^|./|' | xargs bun test

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import { getRecipes } from '@/lib/repository/recipe-store/read';
 import { revalidatePath } from 'next/cache';
 import { AdminActionButton } from './admin-action-button';
+import { recipePath } from '@/lib/seo/recipe-slug';
 
 const invalidationSchema = z.array(
   z.object({
@@ -20,7 +21,7 @@ const inavalidateAllCachesAction = async () => {
   const rows = invalidationSchema.parse(result);
   for (const { id, title } of rows) {
     console.log(`admin: invalidating cache for ${title} page`);
-    revalidatePath(`/recipes/${id}`);
+    revalidatePath(recipePath(id, title));
   }
   console.log('admin: finished revalidating paths');
 };

--- a/app/edit-recipe/[slug]/page.tsx
+++ b/app/edit-recipe/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { EditRecipe } from './edit-recipe.client';
 import { unstable_noStore as noStore } from 'next/cache';
 import { Suspense } from 'react';
 import { loadRecipeForm } from '@/lib/loaders/load-recipe-form';
+import { parseRecipeSlug } from '@/lib/seo/recipe-slug';
 
 export const metadata: Metadata = {
   robots: { index: false, follow: false },
@@ -11,11 +12,11 @@ export const metadata: Metadata = {
 
 const Page = async ({ params }: { params: { slug: string } }) => {
   noStore();
-  const { slug } = params;
-  const recipeId = parseInt(slug);
-  if (Number.isNaN(recipeId)) {
+  const parsed = parseRecipeSlug(params.slug);
+  if (!parsed) {
     return notFound();
   }
+  const recipeId = parsed.id;
 
   const result = await loadRecipeForm(recipeId);
   if (result === undefined) {

--- a/app/recipes/[slug]/page.tsx
+++ b/app/recipes/[slug]/page.tsx
@@ -1,5 +1,6 @@
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import Image from 'next/image';
+import type { Metadata } from 'next';
 import { loadRecipePage } from '@/lib/loaders/load-recipe-page';
 import { currentUser } from '@clerk/nextjs/server';
 import { hasElevatedPermissions } from '@/lib/auth';
@@ -10,17 +11,52 @@ import { images } from '@/lib/constants';
 import { ReactNode } from 'react';
 import { ChatPanel } from '@/components/grandmother-bot/chat-panel.client';
 import { convertRecipeToPromptContext } from '@/lib/translation/parsers';
+import {
+  parseRecipeSlug,
+  recipePath,
+  editRecipePath,
+  slugify,
+} from '@/lib/seo/recipe-slug';
+
+export const generateMetadata = async ({
+  params,
+}: {
+  params: { slug: string };
+}): Promise<Metadata> => {
+  const parsed = parseRecipeSlug(params.slug);
+  if (!parsed) return {};
+  const recipe = await loadRecipePage(parsed.id);
+  if (!recipe) return {};
+  const url = recipePath(parsed.id, recipe.title);
+  return {
+    title: recipe.title,
+    description: recipe.description,
+    alternates: { canonical: url },
+    openGraph: {
+      title: recipe.title,
+      description: recipe.description,
+      url,
+      type: 'article',
+      images: recipe.imageUrl ? [{ url: recipe.imageUrl }] : undefined,
+    },
+  };
+};
 
 const Page = async ({ params }: { params: { slug: string } }) => {
-  const { slug } = params;
-  const recipeId = parseInt(slug);
-  if (Number.isNaN(recipeId)) {
+  const parsed = parseRecipeSlug(params.slug);
+  if (!parsed) {
     return notFound();
   }
+  const { id: recipeId, slug } = parsed;
 
   const recipe = await loadRecipePage(recipeId);
   if (recipe === undefined) {
     return notFound();
+  }
+
+  const canonicalSlug = slugify(recipe.title);
+  if (slug !== canonicalSlug) {
+    redirect(recipePath(recipeId, recipe.title));
   }
 
   const user = await currentUser();
@@ -74,7 +110,10 @@ const Page = async ({ params }: { params: { slug: string } }) => {
         {TagArea}
         {hasElevatedPermissions(user) ? (
           <div className='flex justify-center'>
-            <LinkButton className='mb-4 mt-8' href={`/edit-recipe/${recipeId}`}>
+            <LinkButton
+              className='mb-4 mt-8'
+              href={editRecipePath(recipeId, recipe.title)}
+            >
               Edit
             </LinkButton>
           </div>

--- a/app/recipes/[slug]/page.tsx
+++ b/app/recipes/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound, redirect } from 'next/navigation';
+import { notFound, permanentRedirect } from 'next/navigation';
 import Image from 'next/image';
 import type { Metadata } from 'next';
 import { loadRecipePage } from '@/lib/loaders/load-recipe-page';
@@ -56,7 +56,7 @@ const Page = async ({ params }: { params: { slug: string } }) => {
 
   const canonicalSlug = slugify(recipe.title);
   if (slug !== canonicalSlug) {
-    redirect(recipePath(recipeId, recipe.title));
+    permanentRedirect(recipePath(recipeId, recipe.title));
   }
 
   const user = await currentUser();

--- a/components/recipe-gallery/recipe-gallery.tsx
+++ b/components/recipe-gallery/recipe-gallery.tsx
@@ -10,6 +10,7 @@ import { Suspense } from 'react';
 import { unstable_noStore as noStore } from 'next/cache';
 import { loadGalleryPage } from '@/lib/loaders/load-gallery-page';
 import { loadPageCount as defaultLoadPageCount } from '@/lib/loaders/load-page-count';
+import { recipePath } from '@/lib/seo/recipe-slug';
 
 export type LoadRecipes = typeof loadGalleryPage;
 
@@ -62,7 +63,10 @@ const RecipeGallery = async ({
               key={recipeProps.title}
               className='col-span-7 col-start-2 h-[28rem]'
             >
-              <RecipeCard {...recipeProps} href={`/recipes/${id}`} />
+              <RecipeCard
+                {...recipeProps}
+                href={recipePath(id, recipeProps.title)}
+              />
             </li>
           );
         })}

--- a/lib/actions/update-recipe.ts
+++ b/lib/actions/update-recipe.ts
@@ -70,6 +70,6 @@ export const updateRecipeAction = async ({
     tagsToRemove,
   });
 
-  revalidatePath(`/recipes/${id}`);
+  revalidatePath('/recipes/[slug]', 'page');
   return result;
 };

--- a/lib/loaders/load-recipe-page.ts
+++ b/lib/loaders/load-recipe-page.ts
@@ -1,8 +1,9 @@
+import { cache } from 'react';
 import { getRecipes } from '@/lib/repository/recipe-store/read';
 import { createWhereIdClause } from '@/lib/repository/recipe-store/utils';
 import { recipePageSchema } from '@/lib/translation/schema';
 
-export const loadRecipePage = async (recipeId: number) => {
+export const loadRecipePage = cache(async (recipeId: number) => {
   const recipes = await getRecipes({
     keys: [
       'title',
@@ -22,4 +23,4 @@ export const loadRecipePage = async (recipeId: number) => {
 
   const { success, data } = recipePageSchema.safeParse(recipes[0]);
   return success ? data : undefined;
-};
+});

--- a/lib/seo/__tests__/recipe-slug.test.ts
+++ b/lib/seo/__tests__/recipe-slug.test.ts
@@ -77,6 +77,10 @@ describe('parseRecipeSlug', () => {
     expect(parseRecipeSlug('')).toBeNull();
   });
 
+  it('returns null when the slug segment is empty (leading dash)', () => {
+    expect(parseRecipeSlug('-42')).toBeNull();
+  });
+
   it('takes only the trailing numeric segment as the id', () => {
     expect(parseRecipeSlug('recipe-2-electric-boogaloo-99')).toEqual({
       id: 99,

--- a/lib/seo/__tests__/recipe-slug.test.ts
+++ b/lib/seo/__tests__/recipe-slug.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  slugify,
+  recipePath,
+  editRecipePath,
+  parseRecipeSlug,
+} from '../recipe-slug';
+
+describe('slugify', () => {
+  it('lowercases and joins words with dashes', () => {
+    expect(slugify('Chicken Soup')).toBe('chicken-soup');
+  });
+
+  it('strips diacritics', () => {
+    expect(slugify('Crème Brûlée')).toBe('creme-brulee');
+  });
+
+  it('collapses punctuation and runs of non-alphanumerics', () => {
+    expect(slugify('Mom’s Apple Pie!! & Friends')).toBe(
+      'mom-s-apple-pie-friends'
+    );
+  });
+
+  it('trims leading and trailing dashes', () => {
+    expect(slugify('  hello world  ')).toBe('hello-world');
+  });
+
+  it('returns an empty string when there are no alphanumeric characters', () => {
+    expect(slugify('   ')).toBe('');
+    expect(slugify('!!!')).toBe('');
+  });
+
+  it('caps slug length and trims any trailing dash from the cap', () => {
+    const long = 'a'.repeat(40) + ' ' + 'b'.repeat(60);
+    const result = slugify(long);
+    expect(result.length).toBeLessThanOrEqual(80);
+    expect(result.endsWith('-')).toBe(false);
+  });
+});
+
+describe('recipePath', () => {
+  it('builds a slug-id url', () => {
+    expect(recipePath(42, 'Chicken Soup')).toBe('/recipes/chicken-soup-42');
+  });
+
+  it('falls back to id-only when title produces an empty slug', () => {
+    expect(recipePath(7, '!!!')).toBe('/recipes/7');
+  });
+});
+
+describe('editRecipePath', () => {
+  it('builds the edit url with slug', () => {
+    expect(editRecipePath(42, 'Chicken Soup')).toBe(
+      '/edit-recipe/chicken-soup-42'
+    );
+  });
+
+  it('falls back to id-only when title produces an empty slug', () => {
+    expect(editRecipePath(7, '!!!')).toBe('/edit-recipe/7');
+  });
+});
+
+describe('parseRecipeSlug', () => {
+  it('extracts id and slug from a slug-id param', () => {
+    expect(parseRecipeSlug('chicken-soup-42')).toEqual({
+      id: 42,
+      slug: 'chicken-soup',
+    });
+  });
+
+  it('parses an id-only param with empty slug', () => {
+    expect(parseRecipeSlug('42')).toEqual({ id: 42, slug: '' });
+  });
+
+  it('returns null when there is no trailing id', () => {
+    expect(parseRecipeSlug('chicken-soup')).toBeNull();
+    expect(parseRecipeSlug('')).toBeNull();
+  });
+
+  it('takes only the trailing numeric segment as the id', () => {
+    expect(parseRecipeSlug('recipe-2-electric-boogaloo-99')).toEqual({
+      id: 99,
+      slug: 'recipe-2-electric-boogaloo',
+    });
+  });
+});

--- a/lib/seo/recipe-slug.ts
+++ b/lib/seo/recipe-slug.ts
@@ -25,7 +25,7 @@ export interface ParsedRecipeSlug {
 }
 
 export const parseRecipeSlug = (param: string): ParsedRecipeSlug | null => {
-  const match = param.match(/^(?:(.*)-)?(\d+)$/);
+  const match = param.match(/^(?:(.+)-)?(\d+)$/);
   if (!match) {
     return null;
   }

--- a/lib/seo/recipe-slug.ts
+++ b/lib/seo/recipe-slug.ts
@@ -1,0 +1,37 @@
+export const slugify = (title: string): string => {
+  return title
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80)
+    .replace(/-+$/g, '');
+};
+
+export const recipePath = (id: number, title: string): string => {
+  const slug = slugify(title);
+  return slug ? `/recipes/${slug}-${id}` : `/recipes/${id}`;
+};
+
+export const editRecipePath = (id: number, title: string): string => {
+  const slug = slugify(title);
+  return slug ? `/edit-recipe/${slug}-${id}` : `/edit-recipe/${id}`;
+};
+
+export interface ParsedRecipeSlug {
+  id: number;
+  slug: string;
+}
+
+export const parseRecipeSlug = (param: string): ParsedRecipeSlug | null => {
+  const match = param.match(/^(?:(.*)-)?(\d+)$/);
+  if (!match) {
+    return null;
+  }
+  const id = parseInt(match[2], 10);
+  if (Number.isNaN(id)) {
+    return null;
+  }
+  return { id, slug: match[1] ?? '' };
+};


### PR DESCRIPTION
## Summary
- Recipe URLs are now `/recipes/<title-slug>-<id>`; the trailing id stays the source of truth so duplicate recipe titles need no DB changes or uniqueness handling.
- Requests with a missing or stale slug 308-redirect to the canonical URL (e.g. after a title edit).
- Adds `generateMetadata` on the recipe page for proper `<title>`, description, `alternates.canonical`, and OG tags (title/description/url/image).
- Centralizes link/revalidate sites on a `recipePath` / `editRecipePath` helper (gallery card, edit-link, admin cache invalidation). The update-recipe server action now revalidates the dynamic route pattern since it doesn't have the title in scope.
- Adds `lib/seo/recipe-slug.ts` plus a 14-test bun test suite covering diacritic stripping, punctuation collapse, length cap, empty-slug fallback, and id parsing for titles that already contain digits.
- CI: adds a second test step that runs lib tests via `find … | xargs bun test`. The `bunfig.toml` test root stays scoped to `./components` so `bun test` doesn't pick up Playwright specs in `tests/`.

Sitemap, `robots.ts`, and JSON-LD `Recipe` structured data are intentionally out of scope — sitemap/robots live in a separate in-flight PR, and reliable structured data isn't possible while ingredients/steps are stored as raw TipTap HTML.

## Test plan
- [ ] `bun test` and the new lib find-step both pass in CI
- [ ] `bun run check:types` clean
- [ ] Visiting `/recipes/<id>` (legacy, no slug) 308-redirects to `/recipes/<slug>-<id>`
- [ ] Visiting `/recipes/<wrong-slug>-<id>` redirects to the canonical slug
- [ ] Visiting `/recipes/<right-slug>-<id>` renders without a redirect
- [ ] Page `<title>` and OG tags reflect the recipe title/description/image
- [ ] Editing a recipe still works from the gallery and the recipe page
- [ ] Admin "invalidate all caches" still revalidates each recipe path

🤖 Generated with [Claude Code](https://claude.com/claude-code)