### PR TITLE
docs: clean up AGENTS.md and create CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,228 +1,71 @@
 # AI Agent Guide
 
-This document provides context and conventions for AI agents working on this codebase.
+Context and conventions for AI agents working on this codebase. This file focuses on things that are easy to miss by exploring the code alone — for a general project tour, tech stack, and contributor onboarding, see `CONTRIBUTING.md`.
 
-## Project Overview
+## Architecture: the layers that matter
 
-Grits, Greenbeans and Grandmothers is a Next.js recipe website that digitizes family recipe books. It allows authenticated family members to create, edit, and view recipes, with AI-powered features for recipe assistance and description generation.
+Data flows through four layers, and getting them right is the most common source of subtle bugs:
 
-## Tech Stack
+1. **Loaders** (`lib/loaders/`) — server-side reads. Called from server components.
+2. **Actions** (`lib/actions/`, `'use server'`) — mutations. AI features live in `lib/actions/ai/`.
+3. **Repository** (`lib/repository/recipe-store/`, `lib/repository/image-store/`) — pure data access via Drizzle. No validation here.
+4. **Translation** (`lib/translation/`) — bridges Drizzle's snake_case DB types and the frontend's camelCase types. Zod schemas in `schema.ts`, converters in `parsers.ts` (e.g. `convertFormDataToRecipe`, `convertPageToForm`).
 
-- **Framework**: Next.js 14 with App Router
-- **Language**: TypeScript
-- **Styling**: Tailwind CSS
-- **Package Manager**: Bun
-- **Database**: Turso (LibSQL) with Drizzle ORM
-- **Authentication**: Clerk
-- **Image Storage**: Backblaze B2 (using AWS S3 SDK)
-- **UI Components**: shadcn/ui (Radix UI primitives)
-- **Form Handling**: react-hook-form with zod validation
-- **Rich Text Editor**: TipTap
-- **AI**: OpenAI via Vercel AI SDK
-- **Testing**: Bun test runner (unit tests), Playwright (E2E tests)
+Validation happens in loaders and actions, **not** in the repository. The repository returns raw DB results.
 
-## Project Structure
-
-### Frontend (`app/`, `components/`, `hooks/`)
-
-- **`app/`**: Next.js App Router pages and layouts
-  - Routes follow Next.js App Router conventions
-  - Server components by default
-  - Client components marked with `'use client'`
-- **`components/`**: React components
-  - Organized by feature/domain
-  - `ui/`: shadcn/ui components (prefer these when available)
-  - Client components use `.client.tsx` suffix
-- **`hooks/`**: Custom React hooks
-
-### Backend (`lib/`)
-
-- **`lib/loaders/`**: Server-side data reading functions
-  - Called from server components
-  - Return data for rendering
-  - Examples: `loadRecipePage`, `loadGalleryPage`, `loadRecipeForm`
-- **`lib/actions/`**: Next.js Server Actions
-  - Marked with `'use server'`
-  - Handle data mutations (create, update, delete)
-  - Examples: `createRecipeAction`, `updateRecipeAction`
-  - Located in `lib/actions/`
-- **`lib/repository/`**: Data access layer
-  - **`recipe-store/`**: CRUD operations for recipes (uses Drizzle ORM)
-    - `create.ts`: Create operations
-    - `read.ts`: Read operations
-    - `update.ts`: Update operations
-    - `utils.ts`: Query building utilities
-  - **`image-store/`**: Image upload to Backblaze B2
-    - Uses AWS S3 SDK
-    - Handles image preprocessing and upload
-- **`lib/translation/`**: Schema translation layer
-
-  - Translates between backend (Drizzle) and frontend schemas
-  - Uses Zod for validation
-  - `schema.ts`: Zod schemas
-  - `parsers.ts`: Conversion functions
-  - `utils.ts`: Translation utilities
-
-- **`lib/auth.ts`**: Authentication utilities (Clerk integration)
-
-### Database (`db/`)
-
-- **`db/schema.ts`**: Drizzle ORM schema definitions
-
-  - Tables: `recipes`, `tags`, `recipesToTags`
-  - Relations defined using Drizzle relations API
-  - Type exports: `InsertRecipe`, `SelectRecipe`, etc.
-
-- **`db/index.ts`**: Database connection and client setup
-
-### Other Directories
-
-- **`scripts/`**: Utility scripts (backup, upload, etc.)
-- **`e2e/`**: Playwright E2E tests
-- **`components/__tests__/`**: Unit tests for components
-- **`stories/`**: Storybook stories
-- **`migrations/`**: Drizzle database migrations
-- **`config/`**: Test configuration files
-
-## Key Conventions
-
-### Component Naming
-
-- Client components: Use `.client.tsx` suffix (e.g., `recipe-edit-form.client.tsx`)
-- Server components: No special suffix
-- Prefer shadcn/ui components when available (check `components/ui/`)
-
-### Data Flow
-
-1. **Reading Data**: Server Component → `lib/loaders/*` → `lib/repository/recipe-store/read.ts` → Database
-2. **Writing Data**: Client Component → Server Action (`lib/actions/*`) → `lib/repository/recipe-store/*` → Database
-3. **Schema Translation**: Use `lib/translation/` to convert between backend and frontend formats
-
-### Server Actions Pattern
+## Server Action pattern
 
 ```typescript
 'use server';
 
 export const myAction = async (formData: FormData) => {
-  // 1. Authentication check
+  // 1. Auth check
   const user = await currentUser();
   if (!hasElevatedPermissions(user)) {
-    return; // or throw error
+    return; // server actions typically return undefined on error
   }
 
-  // 2. Parse/validate input (often using translation layer)
+  // 2. Parse/validate via the translation layer
   const data = convertFormDataToRecipe(formData);
 
   // 3. Business logic (image processing, sanitization, etc.)
 
-  // 4. Call repository function
+  // 4. Repository call
   return createRecipe(data);
 };
 ```
 
-### Loader Pattern
+Notes:
+
+- **Server actions return `undefined` on error.** Callers must check return values rather than relying on thrown exceptions.
+- **Auth is checked twice**: once in `middleware.ts` for route access, again inside server actions as defense-in-depth. Don't skip the in-action check.
+- Use `hasElevatedPermissions()` (family or admin) or `hasAdminPermissions()` from `lib/auth.ts`.
+
+## Loader pattern
 
 ```typescript
 export const loadSomething = async (args: LoadArgs) => {
-  // 1. Query database via repository
-  const result = await getRecipes({ ... });
-
-  // 2. Validate with Zod schema
-  const validated = schema.parse(result);
-
-  // 3. Return data
+  const result = await getRecipes({ ... });   // repository
+  const validated = schema.parse(result);     // Zod boundary validation
   return validated;
 };
 ```
 
-### Repository Pattern
+## Adding a new recipe field
 
-- Repository functions are pure data access
-- Use Drizzle query builders (`createWhereClause`, `createPaginateClause`, etc.)
-- Return raw database results
-- Validation happens in loaders/actions, not repository
+This touches every layer; it's easy to forget one.
 
-### Translation Layer
+1. `db/schema.ts`
+2. Generate a migration
+3. `lib/translation/schema.ts` (Zod)
+4. `lib/translation/parsers.ts` (converters in both directions)
+5. `lib/repository/recipe-store/` read and write functions
+6. UI components and forms
 
-- **Purpose**: Bridge between Drizzle schema (snake_case, database types) and frontend schema (camelCase, frontend types)
-- **Usage**:
-  - `convertFormDataToRecipe`: Form → Backend format
-  - `convertPageToForm`: Backend format → Form format
-  - Zod schemas validate at boundaries
+## Non-obvious things
 
-### Image Handling
-
-- Images uploaded via `lib/repository/image-store/upload.ts`
-- Preprocessing via `lib/repository/image-store/utils.ts` (uses Sharp)
-- Images stored on Backblaze B2
-- Enforced aspect ratio via image cropper component
-
-## Testing
-
-### Unit Tests
-
-- Use Bun test runner
-- Located in `components/__tests__/` or co-located with code
-- Use `@testing-library/react` for component tests
-- Configuration in `config/testing-library.ts` and `config/happydom.ts`
-
-### E2E Tests
-
-- Use Playwright
-- Located in `e2e/`
-- Configuration in `playwright.config.ts`
-
-### Running Tests
-
-- Check `package.json` scripts for test commands
-- Prefer using npm/bun scripts over direct terminal commands
-
-## Development Workflow
-
-### Common Tasks
-
-1. **Add a new recipe field**:
-
-   - Update `db/schema.ts`
-   - Create migration (`bun run studio` or drizzle-kit)
-   - Update translation schemas in `lib/translation/schema.ts`
-   - Update parsers in `lib/translation/parsers.ts`
-   - Update repository read/write functions
-   - Update UI components
-
-2. **Add a new page**:
-
-   - Create route in `app/`
-   - Add loader in `lib/loaders/` if needed
-   - Create components in `components/`
-
-3. **Add a new form action**:
-   - Create server action in `lib/actions/`
-   - Add repository function if needed
-   - Wire up in client component
-
-### Scripts
-
-- `bun run dev`: Start development server
-- `bun run build`: Build for production
-- `bun run lint`: Run ESLint
-- `bun run format`: Format code with Prettier
-- `bun run check:types`: Type check with TypeScript
-- `bun run studio`: Open Drizzle Studio
-- `bun run backup`: Run backup script
-
-## Important Notes
-
-- **Authentication**: Routes protected via middleware (`middleware.ts`) and server action checks
-- **Permissions**: Use `hasElevatedPermissions()` or `hasAdminPermissions()` from `lib/auth.ts`
-- **HTML Sanitization**: TipTap output is sanitized, but server actions also sanitize as defense-in-depth
-- **Path Aliases**: Use `@/` prefix for imports (configured in `tsconfig.json`)
-- **Type Safety**: Prefer Zod schemas for runtime validation at API boundaries
-- **Error Handling**: Server actions typically return `undefined` on error (check return values)
-
-## AI Features
-
-- **grandmother_bot**: AI assistant accessible on recipe pages
-- **Recipe description generation**: AI-powered description generation in recipe forms
-- AI code lives in `lib/actions/ai/`
-- Uses OpenAI via Vercel AI SDK
+- **HTML sanitization** — TipTap output is sanitized client-side, but server actions sanitize again as defense-in-depth. Don't remove the server-side sanitization assuming the client already did it.
+- **Images** — uploads go through `lib/repository/image-store/upload.ts`; preprocessing (Sharp) lives in `lib/repository/image-store/utils.ts`. The aspect ratio is enforced by the cropper component on the client.
+- **Repository query helpers** — use `createWhereClause`, `createPaginateClause`, etc. from `lib/repository/recipe-store/utils.ts` rather than hand-rolling Drizzle predicates.
+- **Client components** use a `.client.tsx` suffix.
+- **shadcn/ui first** — check `components/ui/` before reaching for a new component or library.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,114 @@
+# Contributing
+
+Thanks for your interest in contributing to Grits, Greenbeans and Grandmothers. This guide covers what you need to know to get the project running locally and find your way around the codebase.
+
+## Tech Stack
+
+- **Framework**: Next.js 14 (App Router)
+- **Language**: TypeScript
+- **Styling**: Tailwind CSS
+- **Package Manager**: Bun (Next.js still uses Node for the runtime)
+- **Database**: Turso (LibSQL) with Drizzle ORM
+- **Authentication**: Clerk
+- **Image Storage**: Backblaze B2 (via AWS S3 SDK), Sharp for preprocessing
+- **UI Components**: shadcn/ui (Radix UI primitives)
+- **Form Handling**: react-hook-form + Zod
+- **Rich Text Editor**: TipTap
+- **Image Cropper**: react-image-crop
+- **AI**: OpenAI via Vercel AI SDK; nlux for the chat component
+- **Testing**: Bun test + React Testing Library (unit), Playwright (E2E)
+- **Hosting**: Vercel
+
+## Getting Started
+
+```sh
+bun install
+bun run dev
+```
+
+You will need environment variables for Clerk, Turso, Backblaze B2, and OpenAI. Reach out if you need help getting set up.
+
+### Useful Scripts
+
+- `bun run dev` — start the development server
+- `bun run build` — production build
+- `bun run lint` — ESLint
+- `bun run format` — Prettier
+- `bun run check:types` — TypeScript
+- `bun run studio` — open Drizzle Studio
+- `bun run backup` — run the backup script
+
+## Project Structure
+
+### Frontend
+
+- **`app/`** — Next.js App Router pages and layouts. Server components by default; client components opt in with `'use client'` and use a `.client.tsx` suffix.
+- **`components/`** — React components organized by feature. `components/ui/` holds shadcn/ui primitives — prefer these when something fits.
+- **`hooks/`** — Custom React hooks.
+
+### Backend (`lib/`)
+
+- **`lib/loaders/`** — Server-side data reading. Called from server components, returns data ready for rendering.
+- **`lib/actions/`** — Server Actions (`'use server'`). Handle mutations. AI features live in `lib/actions/ai/`.
+- **`lib/repository/`** — Data access layer.
+  - `recipe-store/` — CRUD for recipes (Drizzle ORM), split into `create.ts`, `read.ts`, `update.ts`, `utils.ts`.
+  - `image-store/` — Image upload to Backblaze B2.
+- **`lib/translation/`** — Bridges the Drizzle schema (snake_case, DB types) and the frontend schema (camelCase). Zod schemas in `schema.ts`, conversion functions in `parsers.ts`.
+- **`lib/auth.ts`** — Clerk helpers including `hasElevatedPermissions` and `hasAdminPermissions`.
+
+### Database (`db/`)
+
+- **`db/schema.ts`** — Drizzle schema. Tables: `recipes`, `tags`, `recipesToTags`. Type exports like `InsertRecipe`, `SelectRecipe`.
+- **`db/index.ts`** — DB connection and client.
+- **`migrations/`** — Drizzle-generated migrations.
+
+### Other
+
+- **`scripts/`** — Utility scripts (backup, upload, etc.)
+- **`e2e/`** — Playwright tests
+- **`components/__tests__/`** — Unit tests (also co-located with code)
+- **`stories/`** — Storybook
+- **`config/`** — Test config (`testing-library.ts`, `happydom.ts`)
+
+## Conventions
+
+- **Path alias**: `@/` maps to the project root (see `tsconfig.json`).
+- **Client components**: suffix files with `.client.tsx`.
+- **shadcn/ui first**: check `components/ui/` before pulling in new component libraries.
+- **Validation at boundaries**: Zod schemas validate in loaders and actions; the repository layer stays as pure data access.
+
+### Data Flow
+
+- **Reading**: Server Component → `lib/loaders/*` → `lib/repository/recipe-store/read.ts` → DB
+- **Writing**: Client Component → `lib/actions/*` → `lib/repository/recipe-store/*` → DB
+- Use `lib/translation/` to convert between backend and frontend formats.
+
+## Common Tasks
+
+### Add a new recipe field
+
+1. Update `db/schema.ts`.
+2. Generate a migration (`bun run studio` or drizzle-kit).
+3. Update Zod schemas in `lib/translation/schema.ts`.
+4. Update parsers in `lib/translation/parsers.ts`.
+5. Update repository read/write functions.
+6. Update UI components and forms.
+
+### Add a new page
+
+1. Add the route under `app/`.
+2. Add a loader in `lib/loaders/` if it needs server-side data.
+3. Build out components under `components/`.
+
+### Add a new form action
+
+1. Create the server action under `lib/actions/`.
+2. Add a repository function if needed.
+3. Wire it up in the relevant client component.
+
+## Testing
+
+- **Unit tests** — Bun test runner with React Testing Library. Tests live in `components/__tests__/` or co-located with the code under test.
+- **E2E tests** — Playwright, configured in `playwright.config.ts`, tests in `e2e/`.
+
+Prefer the `package.json` scripts over running the runners directly.

--- a/README.md
+++ b/README.md
@@ -42,28 +42,11 @@ Instructions are entered through a What-You-See-is-What-You-Get (WYSIWYG) text e
 - grandmother_bot can use tools to help scale recipes up and down accurately
 - Recipe descriptions can be generated using AI by clicking a button in the recipe create/edit forms. The AI uses the title and instructions to come up with a description.
 
-## Technical details -- overview
+## Contributing
 
-Technologies I used to build this site:
+If you'd like to run the project locally or contribute, see [CONTRIBUTING.md](./CONTRIBUTING.md) for the tech stack, project structure, and development workflow.
 
-- NextJS
-- Tailwind CSS for styling
-- Turso (LibSQL) as a database and database host
-- Drizzle ORM
-- Backblaze B2 and AWS S3 SDK for image storage
-- Clerk for authentication
-- shadcn UI as a component library
-- TipTap for the text editor component
-- react-image-crop for the image cropper component
-- sharp for cropping and downsizing images
-- Vercel for hosting
-- Bun as a package manager (NextJS still uses node for the runtime)
-- Bun test and react-testing-library for unit tests
-- Playwright for E2E tests
-- OpenAI, Vercel AI SDK for AI features
-- nlux for a chat component
-
-## Technical details -- Project Philosophy
+## Project Philosophy
 
 My [last project](https://github.com/stilt0n/dependor) was written in Go, mostly using TDD and with only one dependency. This project is basically the opposite of that project:
 


### PR DESCRIPTION
## What I Did

There's a lot of redundant information in the `AGENTS.md` file that an agent will infer when exploring the code anyway. Some of this information is useful for human contributors though. So I moved that information to a new `CONTRIBUTING.md` file and moved some information from the `README.md` there as well

This PR:
- Makes the `AGENTS.md` file more limited to things that will actually be useful to an agent.
- Creates a `CLAUDE.md` file that points to `AGENTS.md`
- Removes technical deep dive information from the `README.md` and puts it in `CONTRIBUTING.md`