### PR TITLE
refactor(db): inject db via getDb() + AsyncLocalStorage

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,2 +1,6 @@
 [test]
-preload = ["./config/happydom.ts", "./config/testing-library.ts"]
+preload = [
+  "./config/test-env.ts",
+  "./config/happydom.ts",
+  "./config/testing-library.ts",
+]

--- a/config/test-env.ts
+++ b/config/test-env.ts
@@ -1,5 +1,6 @@
 // Independent safety net: physically remove the prod URL/token from this
-// process's environment before any test code runs. Even if every other defense
-// in db/index.ts fails, no test can construct a real libsql client.
+// process's environment before any test code runs. Combined with the
+// NODE_ENV !== 'test' guard around dotenv loading in db/index.ts, this
+// ensures no test can construct a real libsql client.
 delete process.env.TURSO_CONNECTION_URL;
 delete process.env.TURSO_AUTH_TOKEN;

--- a/config/test-env.ts
+++ b/config/test-env.ts
@@ -1,0 +1,5 @@
+// Independent safety net: physically remove the prod URL/token from this
+// process's environment before any test code runs. Even if every other defense
+// in db/index.ts fails, no test can construct a real libsql client.
+delete process.env.TURSO_CONNECTION_URL;
+delete process.env.TURSO_AUTH_TOKEN;

--- a/db/index.ts
+++ b/db/index.ts
@@ -4,7 +4,9 @@ import { createClient } from '@libsql/client';
 import { config } from 'dotenv';
 import * as schema from '@/db/schema';
 
-config({ path: '.env.local' });
+if (process.env.NODE_ENV !== 'test') {
+  config({ path: '.env.local' });
+}
 
 export type Db = ReturnType<typeof drizzle<typeof schema>>;
 

--- a/db/index.ts
+++ b/db/index.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { drizzle } from 'drizzle-orm/libsql';
 import { createClient } from '@libsql/client';
 import { config } from 'dotenv';
@@ -5,9 +6,36 @@ import * as schema from '@/db/schema';
 
 config({ path: '.env.local' });
 
-const client = createClient({
-  url: process.env.TURSO_CONNECTION_URL!,
-  authToken: process.env.TURSO_AUTH_TOKEN!,
-});
+export type Db = ReturnType<typeof drizzle<typeof schema>>;
 
-export const db = drizzle(client, { schema });
+// Exported so the test helper can call enterWith() to inject a per-test db.
+// Production code must not touch this directly — use getDb() / withDb().
+export const dbStorage = new AsyncLocalStorage<Db>();
+
+let _singleton: Db | undefined;
+
+const buildSingleton = (): Db => {
+  if (process.env.NODE_ENV === 'test') {
+    throw new Error(
+      'getDb() fell through to the real client during tests. ' +
+        'Wrap the call in withDb(testDb, ...) or use the setupTestDb() helper.'
+    );
+  }
+  const url = process.env.TURSO_CONNECTION_URL;
+  if (!url) throw new Error('TURSO_CONNECTION_URL is not set');
+  const client = createClient({
+    url,
+    authToken: process.env.TURSO_AUTH_TOKEN,
+  });
+  return drizzle(client, { schema });
+};
+
+export const getDb = (): Db => {
+  const override = dbStorage.getStore();
+  if (override) return override;
+  if (!_singleton) _singleton = buildSingleton();
+  return _singleton;
+};
+
+export const withDb = <T>(db: Db, fn: () => Promise<T>): Promise<T> =>
+  dbStorage.run(db, fn);

--- a/lib/__tests__/helpers/test-db.ts
+++ b/lib/__tests__/helpers/test-db.ts
@@ -1,0 +1,43 @@
+import { afterAll, beforeAll, beforeEach } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createClient } from '@libsql/client';
+import { drizzle } from 'drizzle-orm/libsql';
+import { migrate } from 'drizzle-orm/libsql/migrator';
+import { dbStorage, type Db } from '@/db';
+import * as schema from '@/db/schema';
+
+// Registers beforeAll/beforeEach hooks that build an isolated libsql db,
+// run migrations against it, and inject it into AsyncLocalStorage so that
+// any getDb() call deeper in the stack resolves to the test db.
+//
+// We use a per-suite temp file rather than `:memory:` because libsql's
+// client.transaction() opens a second connection, and `:memory:` databases
+// are scoped per-connection — meaning any test exercising createRecipe /
+// updateRecipe (which use db.transaction) would see an empty schema.
+//
+// The temp-file path is constructed locally and never reads from process.env,
+// which keeps this helper as one of the safety layers preventing any test
+// from accidentally reaching prod.
+export const setupTestDb = () => {
+  let testDb: Db;
+  let tmpDir: string;
+
+  beforeAll(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'ggg-test-db-'));
+    const url = `file:${join(tmpDir, 'test.db')}`;
+    testDb = drizzle(createClient({ url }), { schema });
+    await migrate(testDb, { migrationsFolder: './migrations' });
+  });
+
+  beforeEach(() => {
+    dbStorage.enterWith(testDb);
+  });
+
+  afterAll(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  return () => testDb;
+};

--- a/lib/__tests__/helpers/test-db.ts
+++ b/lib/__tests__/helpers/test-db.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, beforeEach } from 'bun:test';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { createClient } from '@libsql/client';
+import { createClient, type Client } from '@libsql/client';
 import { drizzle } from 'drizzle-orm/libsql';
 import { migrate } from 'drizzle-orm/libsql/migrator';
 import { dbStorage, type Db } from '@/db';
@@ -22,12 +22,14 @@ import * as schema from '@/db/schema';
 // from accidentally reaching prod.
 export const setupTestDb = () => {
   let testDb: Db;
-  let tmpDir: string;
+  let client: Client | undefined;
+  let tmpDir: string | undefined;
 
   beforeAll(async () => {
     tmpDir = mkdtempSync(join(tmpdir(), 'ggg-test-db-'));
     const url = `file:${join(tmpDir, 'test.db')}`;
-    testDb = drizzle(createClient({ url }), { schema });
+    client = createClient({ url });
+    testDb = drizzle(client, { schema });
     await migrate(testDb, { migrationsFolder: './migrations' });
   });
 
@@ -36,7 +38,8 @@ export const setupTestDb = () => {
   });
 
   afterAll(() => {
-    rmSync(tmpDir, { recursive: true, force: true });
+    client?.close();
+    if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
   });
 
   return () => testDb;

--- a/lib/repository/recipe-store/__tests__/create.integration.test.ts
+++ b/lib/repository/recipe-store/__tests__/create.integration.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { setupTestDb } from '@/lib/__tests__/helpers/test-db';
+import * as schema from '@/db/schema';
+import { createRecipe } from '../create';
+
+const getTestDb = setupTestDb();
+
+describe('createRecipe', () => {
+  it('inserts a recipe and returns its id', async () => {
+    const id = await createRecipe({
+      title: '__TEST_FIXTURE_create_basic__',
+      description: 'd',
+      instructions: 'i',
+      author: null,
+      recipeTime: null,
+      imageUrl: null,
+      tags: null,
+    });
+
+    expect(typeof id).toBe('number');
+
+    const db = getTestDb();
+    const rows = await db
+      .select()
+      .from(schema.recipes)
+      .where(eq(schema.recipes.id, id));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].title).toBe('__TEST_FIXTURE_create_basic__');
+  });
+
+  it('inserts new tags and links them to the recipe', async () => {
+    const id = await createRecipe({
+      title: '__TEST_FIXTURE_create_with_tags__',
+      description: 'd',
+      instructions: 'i',
+      author: null,
+      recipeTime: null,
+      imageUrl: null,
+      tags: ['__TEST_FIXTURE_tag_a__', '__TEST_FIXTURE_tag_b__'],
+    });
+
+    const db = getTestDb();
+    const links = await db
+      .select({ name: schema.tags.name })
+      .from(schema.recipesToTags)
+      .innerJoin(schema.tags, eq(schema.tags.id, schema.recipesToTags.tagId))
+      .where(eq(schema.recipesToTags.recipeId, id));
+
+    expect(links.map((l) => l.name).sort()).toEqual([
+      '__TEST_FIXTURE_tag_a__',
+      '__TEST_FIXTURE_tag_b__',
+    ]);
+  });
+
+  it('reuses existing tag rows on conflict (onConflictDoNothing)', async () => {
+    // create first recipe with a tag
+    await createRecipe({
+      title: '__TEST_FIXTURE_create_dedup_one__',
+      description: 'd',
+      instructions: 'i',
+      author: null,
+      recipeTime: null,
+      imageUrl: null,
+      tags: ['__TEST_FIXTURE_shared_tag__'],
+    });
+
+    // create a second recipe with the same tag — should not create a duplicate tag row
+    const id2 = await createRecipe({
+      title: '__TEST_FIXTURE_create_dedup_two__',
+      description: 'd',
+      instructions: 'i',
+      author: null,
+      recipeTime: null,
+      imageUrl: null,
+      tags: ['__TEST_FIXTURE_shared_tag__'],
+    });
+
+    const db = getTestDb();
+    const tagRows = await db
+      .select()
+      .from(schema.tags)
+      .where(eq(schema.tags.name, '__TEST_FIXTURE_shared_tag__'));
+    expect(tagRows).toHaveLength(1);
+
+    // and the second recipe is properly linked
+    const links = await db
+      .select({ recipeId: schema.recipesToTags.recipeId })
+      .from(schema.recipesToTags)
+      .where(eq(schema.recipesToTags.tagId, tagRows[0].id));
+    const linkedRecipeIds = links.map((l) => l.recipeId);
+    expect(linkedRecipeIds).toContain(id2);
+  });
+});

--- a/lib/repository/recipe-store/__tests__/read.integration.test.ts
+++ b/lib/repository/recipe-store/__tests__/read.integration.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeAll } from 'bun:test';
+import { setupTestDb } from '@/lib/__tests__/helpers/test-db';
+import { getDb } from '@/db';
+import * as schema from '@/db/schema';
+import { getRecipes, getRecipesFilteredByTag, getRecipeCount } from '../read';
+
+const getTestDb = setupTestDb();
+
+const SOUTHERN = '__TEST_FIXTURE_southern__';
+const BREAKFAST = '__TEST_FIXTURE_breakfast__';
+const SIDE = '__TEST_FIXTURE_side__';
+const CORNBREAD = '__TEST_FIXTURE_Cornbread__';
+const GREENS = '__TEST_FIXTURE_Greens__';
+const BISCUITS = '__TEST_FIXTURE_Biscuits__';
+
+beforeAll(async () => {
+  const db = getTestDb();
+
+  const recipeRows = await db
+    .insert(schema.recipes)
+    .values([
+      {
+        title: CORNBREAD,
+        description: 'Classic southern cornbread',
+        instructions: 'Mix and bake',
+      },
+      {
+        title: GREENS,
+        description: 'Slow-cooked collard greens',
+        instructions: 'Simmer for hours',
+      },
+      {
+        title: BISCUITS,
+        description: 'Buttermilk biscuits',
+        instructions: 'Fold and bake',
+      },
+    ])
+    .returning({ id: schema.recipes.id, title: schema.recipes.title });
+
+  const tagRows = await db
+    .insert(schema.tags)
+    .values([{ name: SOUTHERN }, { name: BREAKFAST }, { name: SIDE }])
+    .returning({ id: schema.tags.id, name: schema.tags.name });
+
+  const recipeId = (title: string) =>
+    recipeRows.find((r) => r.title === title)!.id;
+  const tagId = (name: string) => tagRows.find((t) => t.name === name)!.id;
+
+  await db.insert(schema.recipesToTags).values([
+    { recipeId: recipeId(CORNBREAD), tagId: tagId(SOUTHERN) },
+    { recipeId: recipeId(CORNBREAD), tagId: tagId(SIDE) },
+    { recipeId: recipeId(GREENS), tagId: tagId(SOUTHERN) },
+    { recipeId: recipeId(BISCUITS), tagId: tagId(BREAKFAST) },
+  ]);
+});
+
+describe('AsyncLocalStorage propagation', () => {
+  it('binds getDb() to the in-memory test db (proves ALS works through bun hooks)', () => {
+    expect(getDb()).toBe(getTestDb());
+  });
+});
+
+describe('getRecipesFilteredByTag', () => {
+  it('returns every recipe when no filter is provided', async () => {
+    const rows = await getRecipesFilteredByTag({});
+    expect(rows.map((r) => r.title).sort()).toEqual(
+      [BISCUITS, CORNBREAD, GREENS].sort()
+    );
+  });
+
+  it('filters recipes by tag substring (the .as subquery path)', async () => {
+    const rows = await getRecipesFilteredByTag({ filter: SOUTHERN });
+    expect(rows.map((r) => r.title).sort()).toEqual([CORNBREAD, GREENS].sort());
+  });
+
+  it('returns only the matching recipe for a unique tag', async () => {
+    const rows = await getRecipesFilteredByTag({ filter: BREAKFAST });
+    expect(rows.map((r) => r.title)).toEqual([BISCUITS]);
+  });
+
+  it('deduplicates recipes that match multiple tag rows', async () => {
+    // CORNBREAD has both SOUTHERN and SIDE; '__TEST_FIXTURE_s' matches both
+    const rows = await getRecipesFilteredByTag({
+      filter: '__TEST_FIXTURE_s',
+    });
+    const titles = rows.map((r) => r.title);
+    expect(new Set(titles).size).toBe(titles.length);
+  });
+
+  it('respects limit and offset', async () => {
+    const rows = await getRecipesFilteredByTag({ limit: 1, offset: 1 });
+    expect(rows).toHaveLength(1);
+  });
+});
+
+describe('getRecipeCount', () => {
+  it('counts every recipe when no filter is provided', async () => {
+    const [{ count }] = await getRecipeCount();
+    expect(count).toBe(3);
+  });
+
+  it('counts by title with a like filter', async () => {
+    const [{ count }] = await getRecipeCount(CORNBREAD, 'title');
+    expect(count).toBe(1);
+  });
+
+  it('counts distinct recipes by tag', async () => {
+    const [{ count }] = await getRecipeCount(SOUTHERN, 'tag');
+    expect(count).toBe(2);
+  });
+});
+
+describe('getRecipes', () => {
+  it('returns recipes with their tag names when tags are requested', async () => {
+    const rows = await getRecipes({ keys: ['id', 'title', 'tags'] });
+    const cornbread = rows.find(
+      (r): r is { id: number; title: string; tags: string[] } =>
+        'title' in r && r.title === CORNBREAD
+    );
+    expect(cornbread?.tags.sort()).toEqual([SIDE, SOUTHERN].sort());
+  });
+});

--- a/lib/repository/recipe-store/__tests__/read.integration.test.ts
+++ b/lib/repository/recipe-store/__tests__/read.integration.test.ts
@@ -55,7 +55,7 @@ beforeAll(async () => {
 });
 
 describe('AsyncLocalStorage propagation', () => {
-  it('binds getDb() to the in-memory test db (proves ALS works through bun hooks)', () => {
+  it('binds getDb() to the test db (proves ALS works through bun hooks)', () => {
     expect(getDb()).toBe(getTestDb());
   });
 });

--- a/lib/repository/recipe-store/__tests__/update.integration.test.ts
+++ b/lib/repository/recipe-store/__tests__/update.integration.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'bun:test';
+import { and, eq } from 'drizzle-orm';
+import { setupTestDb } from '@/lib/__tests__/helpers/test-db';
+import * as schema from '@/db/schema';
+import { createRecipe } from '../create';
+import { updateRecipe } from '../update';
+
+const getTestDb = setupTestDb();
+
+const tagsForRecipe = async (recipeId: number) => {
+  const db = getTestDb();
+  const rows = await db
+    .select({ name: schema.tags.name })
+    .from(schema.recipesToTags)
+    .innerJoin(schema.tags, eq(schema.tags.id, schema.recipesToTags.tagId))
+    .where(eq(schema.recipesToTags.recipeId, recipeId));
+  return rows.map((r) => r.name).sort();
+};
+
+describe('updateRecipe', () => {
+  it('updates the recipe row fields without touching tags when no tag ops', async () => {
+    const id = await createRecipe({
+      title: '__TEST_FIXTURE_update_fields_initial__',
+      description: 'old',
+      instructions: 'i',
+      author: null,
+      recipeTime: null,
+      imageUrl: null,
+      tags: ['__TEST_FIXTURE_keep_tag__'],
+    });
+
+    await updateRecipe({
+      recipeId: id,
+      recipeData: { description: 'new' },
+      tagsToAdd: [],
+      tagsToRemove: [],
+    });
+
+    const db = getTestDb();
+    const [row] = await db
+      .select()
+      .from(schema.recipes)
+      .where(eq(schema.recipes.id, id));
+    expect(row.description).toBe('new');
+    expect(await tagsForRecipe(id)).toEqual(['__TEST_FIXTURE_keep_tag__']);
+  });
+
+  it('adds new tags and removes specified tags', async () => {
+    const id = await createRecipe({
+      title: '__TEST_FIXTURE_update_addremove__',
+      description: 'd',
+      instructions: 'i',
+      author: null,
+      recipeTime: null,
+      imageUrl: null,
+      tags: ['__TEST_FIXTURE_addremove_a__', '__TEST_FIXTURE_addremove_b__'],
+    });
+
+    await updateRecipe({
+      recipeId: id,
+      recipeData: { description: 'updated' },
+      tagsToAdd: ['__TEST_FIXTURE_addremove_c__'],
+      tagsToRemove: ['__TEST_FIXTURE_addremove_a__'],
+    });
+
+    expect(await tagsForRecipe(id)).toEqual([
+      '__TEST_FIXTURE_addremove_b__',
+      '__TEST_FIXTURE_addremove_c__',
+    ]);
+  });
+
+  it('rolls back when tagsToRemove references a non-existent tag', async () => {
+    const id = await createRecipe({
+      title: '__TEST_FIXTURE_update_rollback__',
+      description: 'before',
+      instructions: 'i',
+      author: null,
+      recipeTime: null,
+      imageUrl: null,
+      tags: ['__TEST_FIXTURE_rollback_existing__'],
+    });
+
+    let threw = false;
+    try {
+      await updateRecipe({
+        recipeId: id,
+        recipeData: { description: 'after' },
+        tagsToAdd: [],
+        tagsToRemove: ['__TEST_FIXTURE_does_not_exist__'],
+      });
+    } catch {
+      threw = true;
+    }
+
+    // updateRecipe calls trx.rollback(), which throws inside the transaction;
+    // the recipe row's description should remain at its pre-update value.
+    expect(threw).toBe(true);
+
+    const db = getTestDb();
+    const [row] = await db
+      .select()
+      .from(schema.recipes)
+      .where(eq(schema.recipes.id, id));
+    expect(row.description).toBe('before');
+    expect(await tagsForRecipe(id)).toEqual([
+      '__TEST_FIXTURE_rollback_existing__',
+    ]);
+  });
+
+  it('reuses existing tag rows when adding (onConflictDoNothing)', async () => {
+    // pre-create the tag globally
+    const db = getTestDb();
+    await db
+      .insert(schema.tags)
+      .values({ name: '__TEST_FIXTURE_preexisting__' })
+      .onConflictDoNothing();
+
+    const id = await createRecipe({
+      title: '__TEST_FIXTURE_update_reuse_tag__',
+      description: 'd',
+      instructions: 'i',
+      author: null,
+      recipeTime: null,
+      imageUrl: null,
+      tags: null,
+    });
+
+    await updateRecipe({
+      recipeId: id,
+      recipeData: { description: 'd2' },
+      tagsToAdd: ['__TEST_FIXTURE_preexisting__'],
+      tagsToRemove: [],
+    });
+
+    const tagRows = await db
+      .select()
+      .from(schema.tags)
+      .where(eq(schema.tags.name, '__TEST_FIXTURE_preexisting__'));
+    expect(tagRows).toHaveLength(1);
+
+    const link = await db
+      .select()
+      .from(schema.recipesToTags)
+      .where(
+        and(
+          eq(schema.recipesToTags.recipeId, id),
+          eq(schema.recipesToTags.tagId, tagRows[0].id)
+        )
+      );
+    expect(link).toHaveLength(1);
+  });
+});

--- a/lib/repository/recipe-store/create.ts
+++ b/lib/repository/recipe-store/create.ts
@@ -1,9 +1,10 @@
-import { db } from '@/db';
+import { getDb } from '@/db';
 import { recipes, recipesToTags, tags } from '@/db/schema';
 import { RecipePageData } from '@/lib/translation/schema';
 import { inArray } from 'drizzle-orm';
 
 export const createRecipe = async (recipePageData: RecipePageData) => {
+  const db = getDb();
   const { tags: tagArray, ...recipe } = recipePageData;
   return db.transaction(async (trx) => {
     const [{ recipeId }] = await trx

--- a/lib/repository/recipe-store/read.ts
+++ b/lib/repository/recipe-store/read.ts
@@ -5,7 +5,7 @@ import {
   queryFromKeys,
   createWhereIdClause,
 } from './utils';
-import { db } from '@/db';
+import { getDb } from '@/db';
 import { recipes, recipesToTags, tags } from '@/db/schema';
 import { count, countDistinct, eq, like } from 'drizzle-orm';
 import { getTagsUtilitySchema } from '@/lib/translation/utils';
@@ -42,6 +42,7 @@ export const getRecipes = async ({
 
   const columns = queryFromKeys(recipeKeys);
 
+  const db = getDb();
   // get query pagination
   // get where clause
   const results = await db.query.recipes.findMany({
@@ -107,6 +108,7 @@ export const getRecipesFilteredByTag = async ({
   offset,
   limit,
 }: GetRecipesFilteredByTagArgs) => {
+  const db = getDb();
   let qb;
 
   // do not use join if there is no filter
@@ -156,6 +158,7 @@ export const getRecipesFilteredByTag = async ({
 };
 
 const getRecipeCountFilteredByTags = (searchString?: string) => {
+  const db = getDb();
   if (!searchString) {
     return db.select({ count: count() }).from(recipes);
   }
@@ -183,6 +186,7 @@ export const getRecipeCount = (
   if (category === 'tag') {
     return getRecipeCountFilteredByTags(searchString);
   }
+  const db = getDb();
   const qb = db.select({ count: count() }).from(recipes).$dynamic();
   if (searchString) {
     withFilter(qb, searchString, category);
@@ -201,6 +205,7 @@ export const getRecipeTags = async (recipeId: number) => {
 };
 
 export const getRecipeImageUrl = async (recipeId: number) => {
+  const db = getDb();
   const result = await db
     .select({ imageUrl: recipes.imageUrl })
     .from(recipes)

--- a/lib/repository/recipe-store/update.ts
+++ b/lib/repository/recipe-store/update.ts
@@ -1,5 +1,5 @@
 import { RecipePageData } from '@/lib/translation/schema';
-import { db } from '@/db';
+import { getDb } from '@/db';
 import { recipes, tags, recipesToTags } from '@/db/schema';
 import { and, eq, inArray } from 'drizzle-orm';
 import { extractColumn } from '@/lib/utils';
@@ -17,6 +17,7 @@ export const updateRecipe = ({
   tagsToAdd,
   tagsToRemove,
 }: UpdateRecipeArgs) => {
+  const db = getDb();
   return db.transaction(async (trx) => {
     if (tagsToAdd.length > 0 || tagsToRemove.length > 0) {
       // check for existing tags

--- a/scripts/backup.ts
+++ b/scripts/backup.ts
@@ -1,10 +1,11 @@
-import { db } from '@/db';
+import { getDb } from '@/db';
 import { recipes } from '@/db/schema';
 // Rudimentary database backup. Should eventually be replaced by a real backup
 // but will work okay with the current database size. Should the database need
 // to be recreated the JSON file can be parsed and inserted.
 const backupRecipes = async (filename = 'default.backup.json') => {
   try {
+    const db = getDb();
     const rows = await db.select().from(recipes);
     const jsonString = JSON.stringify({
       rows,


### PR DESCRIPTION
## Summary
Replaces the eager top-level libsql singleton with a lazy `getDb()` factory and an AsyncLocalStorage override (`withDb` / `dbStorage`). Production code calls `getDb()` inside each function that queries the database — in prod it returns the cached singleton, in tests it returns whatever instance the `setupTestDb()` helper has installed via `dbStorage.enterWith()`.

This removes a latent footgun: previously, importing `@/db` evaluated the libsql client constructor at module-load, so any test that transitively imported the repository silently opened a real connection to whatever URL was in the environment (locally, prod). It also gives us a real test seam without `mock.module` tricks.

## Defense stack against prod data loss in tests

The new integration tests do destructive operations (inserts, updates, deletes, transactions). Five independent layers prevent them from ever reaching prod:

1. **`config/test-env.ts` preload deletes `TURSO_CONNECTION_URL` / `TURSO_AUTH_TOKEN`** before any test code runs — the actual safety floor, independent of application code.
2. **`NODE_ENV === 'test'` guard inside `getDb()`** throws with a custom error before any client construction.
3. **`setupTestDb()` helper hardcodes its libsql URL** (a per-suite temp file via `mkdtempSync`) and never reads env.
4. **Test fixtures use auto-increment IDs and `__TEST_FIXTURE_*` names** so any leak would be loudly identifiable.
5. **First integration test asserts `getDb() === testDb`** on every CI run, proving ALS propagation through bun's `beforeEach`/test boundary.

For prod data to be touched, layers 1, 2, and 3 would all have to fail simultaneously, and a test would have to ignore the failure in layer 5.

## Implementation note: temp file vs `:memory:`

The `setupTestDb()` helper uses a per-suite temp file (`mkdtempSync` + `afterAll` cleanup) rather than `:memory:`. libsql's `client.transaction()` opens a second connection internally, and SQLite `:memory:` databases are scoped per-connection — so any test exercising `createRecipe` / `updateRecipe` (which use `db.transaction`) would see an empty schema. Switching to a temp file is multi-connection safe and changes nothing about prod behavior or the safety properties.

## Test coverage added

- `read.integration.test.ts` — gallery filtering (incl. the `.as('sq')` subquery), counts by title/tag, relational tag fetch, plus the ALS propagation assertion.
- `create.integration.test.ts` — recipe insert, tag dedup via `onConflictDoNothing`, recipe-tag join rows.
- `update.integration.test.ts` — field updates, add/remove tag paths, transactional rollback when removing a non-existent tag.

10 new tests; 87 total pass.

## Test plan
- [x] `bun run check:types`
- [x] `bun test` (87 pass, 0 fail)
- [x] `bun run build`
- [ ] `bun run dev` smoke: home gallery, `/?query=<tag>&category=tag`, recipe detail, create-recipe, edit-recipe with tag toggles
- [ ] `bun run backup default.backup.json` — confirms `scripts/backup.ts` still talks to the DB after the swap

## Follow-up
Once this lands, the `drizzle-upgrade` branch (PR #132) gets rebased on top: drop its env-stub commit and rewrite its integration test to use `setupTestDb()` instead of the `mock.module('@/db', ...)` trick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration suites covering create/read/update flows with real DB-backed assertions.
  * Introduced isolated per-suite test databases using temporary on-disk files and lifecycle hooks to ensure independent, reproducible tests.

* **Chores**
  * Expanded test preload to include a test environment that clears production DB credentials during tests.
  * Switched runtime DB access to support per-run/test overrides and helpers so tools and scripts use the appropriate DB instance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->