### PR TITLE
fix: relax zod to not break conversation history

### DIFF
--- a/app/api/grandmother-bot/__tests__/route.test.ts
+++ b/app/api/grandmother-bot/__tests__/route.test.ts
@@ -121,6 +121,48 @@ describe('POST /api/grandmother-bot', () => {
     expect(res.status).toBe(404);
   });
 
+  it('accepts assistant messages with non-text parts and strips them before prompting', async () => {
+    const res = await POST(
+      postJson({
+        recipeId: 42,
+        messages: [
+          userMessage('How long do I bake it?'),
+          {
+            id: 'a-1',
+            role: 'assistant',
+            parts: [
+              { type: 'step-start' },
+              { type: 'text', text: 'About 25 minutes.' },
+            ],
+          },
+          userMessage('Thanks!'),
+        ],
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(captured.last).not.toBeNull();
+    const serialized = JSON.stringify(captured.last!.messages);
+    expect(serialized).not.toContain('step-start');
+    expect(serialized).toContain('About 25 minutes.');
+  });
+
+  it('rejects malformed text parts missing the text field', async () => {
+    const res = await POST(
+      postJson({
+        recipeId: 42,
+        messages: [
+          {
+            id: 'm-bad',
+            role: 'user',
+            parts: [{ type: 'text' }],
+          },
+        ],
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
   it('passes the assembled system prompt and messages to streamText', async () => {
     await POST(
       postJson({ recipeId: 42, messages: [userMessage('Tell me about it.')] })

--- a/app/api/grandmother-bot/route.ts
+++ b/app/api/grandmother-bot/route.ts
@@ -14,12 +14,19 @@ const textPartSchema = z.object({
 });
 
 // Assistant messages from useChat (AI SDK v6) include non-text parts such as
-// `step-start` alongside text parts. We only need to validate that *some* text
-// is present; convertToModelMessages handles the other part types.
-const messagePartSchema = z.union([
-  textPartSchema,
-  z.object({ type: z.string() }).passthrough(),
-]);
+// `step-start` alongside text parts. We accept those at the boundary so the
+// schema doesn't reject otherwise-valid conversations, but they're filtered
+// out before prompt construction below.
+//
+// True z.discriminatedUnion needs literal discriminators in every branch,
+// which we can't enumerate (the AI SDK adds new part types over time), so
+// we fall back to z.union and force the catch-all branch to refuse `'text'`
+// — otherwise `{ type: 'text' }` (no `text` field) would slip through the
+// passthrough branch and pass the refine below.
+const nonTextPartSchema = z
+  .object({ type: z.string().refine((t) => t !== 'text') })
+  .passthrough();
+const messagePartSchema = z.union([textPartSchema, nonTextPartSchema]);
 
 const uiMessageSchema = z.object({
   id: z.string().min(1),

--- a/app/api/grandmother-bot/route.ts
+++ b/app/api/grandmother-bot/route.ts
@@ -1,5 +1,5 @@
 import { openai } from '@ai-sdk/openai';
-import { stepCountIs, streamText } from 'ai';
+import { stepCountIs, streamText, type UIMessage } from 'ai';
 import { z } from 'zod';
 import { loadRecipePage } from '@/lib/loaders/load-recipe-page';
 import { buildChatPrompt } from '@/lib/ai/prompt';
@@ -13,10 +13,23 @@ const textPartSchema = z.object({
   text: z.string(),
 });
 
+// Assistant messages from useChat (AI SDK v6) include non-text parts such as
+// `step-start` alongside text parts. We only need to validate that *some* text
+// is present; convertToModelMessages handles the other part types.
+const messagePartSchema = z.union([
+  textPartSchema,
+  z.object({ type: z.string() }).passthrough(),
+]);
+
 const uiMessageSchema = z.object({
   id: z.string().min(1),
   role: z.enum(['user', 'assistant', 'system']),
-  parts: z.array(textPartSchema).min(1),
+  parts: z
+    .array(messagePartSchema)
+    .min(1)
+    .refine((parts) => parts.some((part) => part.type === 'text'), {
+      message: 'message must contain at least one text part',
+    }),
 });
 
 const requestSchema = z.object({
@@ -44,9 +57,20 @@ export const POST = async (request: Request) => {
     return new Response('Recipe not found', { status: 404 });
   }
 
+  // Project to a structurally-valid UIMessage[] by keeping only text parts.
+  // Non-text parts (e.g. `step-start` on prior assistant turns) are validated
+  // at the boundary but discarded here — the prompt builder only needs text.
+  const uiMessages: UIMessage[] = messages.map((message) => ({
+    id: message.id,
+    role: message.role,
+    parts: message.parts.filter(
+      (part): part is { type: 'text'; text: string } => part.type === 'text'
+    ),
+  }));
+
   const { system, messages: modelMessages } = await buildChatPrompt({
     recipe,
-    messages,
+    messages: uiMessages,
   });
 
   const result = streamText({

--- a/app/api/grandmother-bot/route.ts
+++ b/app/api/grandmother-bot/route.ts
@@ -23,7 +23,7 @@ const messagePartSchema = z.union([
 
 const uiMessageSchema = z.object({
   id: z.string().min(1),
-  role: z.enum(['user', 'assistant', 'system']),
+  role: z.enum(['user', 'assistant']),
   parts: z
     .array(messagePartSchema)
     .min(1)


### PR DESCRIPTION
Thank you for contributing to the [grits greenbeans and grandmothers website](https://gritsgreenbeansandgrandmothers.com).

There isn't currently much of a process for contribution. But it would be helpful if you write a brief summary of what your pull request does.

### What I Did

Our move to AI Elements broke conversation history. This should fix it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved message validation in the grandmother-bot API to support additional message formats and ensure more robust request processing with enhanced data filtering.

* **Tests**
  * Expanded test coverage for message validation, sanitization, malformed input handling, and edge case scenarios in API requests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stilt0n/grits-greenbeans-grandmothers-next/pull/142)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->