### PR TITLE
chore: migrate themes to use css variables

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -25,9 +25,9 @@ export const metadata: Metadata = {
 const AboutPage = () => {
   return (
     <div className='prose prose-zinc -mt-4 w-screen min-h-screen about-page'>
-      <section className='max-w-[65rem] m-auto px-8 py-16 bg-white min-h-screen'>
+      <section className='max-w-[65rem] m-auto px-8 py-16 bg-background min-h-screen'>
         <h1>Introduction from the Original Book</h1>
-        <h2 className='text-lg text-zinc-800'>Ada Wesson Jones</h2>
+        <h2 className='text-lg text-foreground'>Ada Wesson Jones</h2>
         <p>
           In this cookbook, you probably won&apos;t see many terms such as au
           gratin, escalope, paté, sauté or étouffée. You will see fry, brown,

--- a/app/delete-my-account/page.tsx
+++ b/app/delete-my-account/page.tsx
@@ -5,7 +5,7 @@ export const metadata: Metadata = {
 };
 
 const DeleteMyAccount = () => (
-  <div className='prose prose-zinc rendered-recipe bg-white mx-auto px-6 min-h-full -mt-4 pt-4 border-x border-zinc-200'>
+  <div className='prose prose-zinc rendered-recipe bg-background mx-auto px-6 min-h-full -mt-4 pt-4 border-x border-border'>
     <h1>How to delete your account</h1>
     <p>
       Grits, Greenbeans and Grandmothers only uses your account for login

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -53,7 +53,7 @@ export default function RootLayout({
           </header>
           {/* FIXME: Main here should not be focusable but seems to sometimes be. The tabIndex is kind of a lazy fix. */}
           <main
-            className='bg-zinc-100 pt-4 flex-grow overflow-y-auto'
+            className='bg-muted pt-4 flex-grow overflow-y-auto'
             tabIndex={-1}
           >
             {children}

--- a/app/recipes/[slug]/page.tsx
+++ b/app/recipes/[slug]/page.tsx
@@ -76,7 +76,7 @@ const Page = async (props: { params: Promise<{ slug: string }> }) => {
 
   return (
     <>
-      <div className='prose prose-zinc rendered-recipe mx-auto bg-zinc-50 px-4 border-x border-zinc-200 min-h-screen -mt-4 pt-4'>
+      <div className='prose prose-zinc rendered-recipe mx-auto bg-muted/50 px-4 border-x border-border min-h-screen -mt-4 pt-4'>
         <span className='flex flex-col mb-8 md:mb-0 md:flex md:flex-row md:justify-between md:items-center'>
           <h1>{recipe.title}</h1>
           <ChatPanel buttonClassName='md:mb-[2em]' recipeId={recipeId} />

--- a/components/editor/editor-input.client.tsx
+++ b/components/editor/editor-input.client.tsx
@@ -36,20 +36,20 @@ const EditorInput = ({
       />
       <Label htmlFor={editorId}>
         {props.label}
-        <span className='text-red-700'>*</span>
+        <span className='text-destructive'>*</span>
       </Label>
       <EditorMenu editor={editor} aria-label={props.menuAriaLabel} />
       <EditorContent
         id={editorId}
         editor={editor}
         className={cn(
-          'prose prose-zinc recipe-editor bg-white',
-          'outline outline-1 outline-zinc-200 rounded-sm focus-within:outline-2 focus-within:outline-zinc-400',
+          'prose prose-zinc recipe-editor bg-background',
+          'outline outline-1 outline-border rounded-sm focus-within:outline-2 focus-within:outline-ring',
           props.className
         )}
       />
       {props.errorMessage ? (
-        <span className='text-red-700'>{props.errorMessage}</span>
+        <span className='text-destructive'>{props.errorMessage}</span>
       ) : null}
     </>
   );

--- a/components/editor/editor-menu.client.tsx
+++ b/components/editor/editor-menu.client.tsx
@@ -135,7 +135,7 @@ export const EditorMenu = (props: EditorMenuProps) => {
         }}
         value={activeTextLevel}
       >
-        <SelectTrigger className='w-32 bg-white'>
+        <SelectTrigger className='w-32 bg-background'>
           <SelectValue />
         </SelectTrigger>
         <SelectContent>

--- a/components/form/decorative-tag.tsx
+++ b/components/form/decorative-tag.tsx
@@ -10,8 +10,8 @@ export const DecorativeTag = (props: TagProps) => {
     <Link href={`/?query=${props.text}&category=tag`}>
       <span
         className={cn(
-          'inline-flex justify-between items-center gap-2 border border-black',
-          'bg-zinc-800 text-white rounded-xl',
+          'inline-flex justify-between items-center gap-2 border border-foreground',
+          'bg-primary text-primary-foreground rounded-xl',
           'max-w-52 px-2 py-1 text-ellipsis h-8'
         )}
       >

--- a/components/form/form-input.tsx
+++ b/components/form/form-input.tsx
@@ -14,10 +14,12 @@ const FormInput = forwardRef<HTMLInputElement, FormInputProps>(
       <div className={`relative ${className}`}>
         <Label htmlFor={inputId}>
           {label}
-          {inputProps.required ? <span className='text-red-700'>*</span> : null}
+          {inputProps.required ? (
+            <span className='text-destructive'>*</span>
+          ) : null}
         </Label>
         <Input
-          className='bg-white'
+          className='bg-background'
           ref={ref}
           id={inputId}
           autoComplete='off'
@@ -25,7 +27,7 @@ const FormInput = forwardRef<HTMLInputElement, FormInputProps>(
         />
         {errorMessage ? (
           <>
-            <p className='absolute text-red-800'>{errorMessage}</p>
+            <p className='absolute text-destructive'>{errorMessage}</p>
           </>
         ) : null}
       </div>

--- a/components/form/tag.client.tsx
+++ b/components/form/tag.client.tsx
@@ -12,8 +12,8 @@ export const Tag = (props: TagProps) => {
   return (
     <span
       className={cn(
-        'inline-flex justify-between items-center gap-2 border border-black',
-        'bg-zinc-800 text-white rounded-xl',
+        'inline-flex justify-between items-center gap-2 border border-foreground',
+        'bg-primary text-primary-foreground rounded-xl',
         'max-w-52 px-2 py-1 text-ellipsis'
       )}
     >

--- a/components/navbar/navbar.tsx
+++ b/components/navbar/navbar.tsx
@@ -7,7 +7,7 @@ const searchCategories = ['title', 'author', 'tag'];
 
 const Navbar = () => {
   return (
-    <nav className='flex flex-row px-4 py-4 drop-shadow-xl border-b border-zinc-200 items-baseline h-18'>
+    <nav className='flex flex-row px-4 py-4 drop-shadow-xl border-b border-border items-baseline h-18'>
       <h1 className='text-lg md:text-3xl text-left flex self-start'>
         <Link href='/'>Grits, Greenbeans and Grandmothers</Link>
       </h1>

--- a/components/navbar/search.client.tsx
+++ b/components/navbar/search.client.tsx
@@ -79,14 +79,14 @@ export const Search = (props: SearchProps) => {
         >
           <SelectTrigger
             aria-label='Choose a category to search'
-            className='h-full border-0 bg-transparent focus:ring-0 focus:ring-offset-0 focus:bg-slate-100'
+            className='h-full border-0 bg-transparent focus:ring-0 focus:ring-offset-0 focus:bg-accent'
           >
             <SelectValue placeholder='title' />
           </SelectTrigger>
-          <SelectContent className='bg-white'>
+          <SelectContent className='bg-background'>
             {props.categories.map((category) => (
               <SelectItem
-                className='focus:bg-slate-100'
+                className='focus:bg-accent'
                 value={category}
                 key={category}
               >

--- a/components/recipe-gallery/recipe-card.client.tsx
+++ b/components/recipe-gallery/recipe-card.client.tsx
@@ -46,11 +46,11 @@ export const RecipeCardDesign = (props: RecipeCardDesignProps) => {
           <h3 id={titleId}>{props.title}</h3>
         </CardTitle>
         {props.author ? (
-          <p className='mt-4 mb-3 text-zinc-700 text-sm md:text-lg'>
+          <p className='mt-4 mb-3 text-muted-foreground text-sm md:text-lg'>
             {props.author}
           </p>
         ) : undefined}
-        <CardDescription className='mt-2 text-zinc-500 flex-grow md:flex-none overflow-hidden'>
+        <CardDescription className='mt-2 text-muted-foreground flex-grow md:flex-none overflow-hidden'>
           <span
             className='line-clamp-4'
             id={descriptionId}


### PR DESCRIPTION
### What I Did

I switched `components.json` to use css variables a bit ago. It seems like now that we have the variables it is nice to use them elsewhere.  This way it's easier to experiment with themes later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the application's color scheme to use a consistent design system theme across all pages and components. The styling now utilizes theme-aware color tokens for backgrounds, borders, text, and interactive elements, ensuring a more cohesive visual appearance throughout the app.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stilt0n/grits-greenbeans-grandmothers-next/pull/144)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->