### PR TITLE
fix: treat empty strings in forms as null

### DIFF
--- a/lib/translation/schema.ts
+++ b/lib/translation/schema.ts
@@ -39,8 +39,16 @@ export const recipeFormSchema = z.object({
   instructions: z
     .string()
     .min(1, 'Instructions cannot be blank and cannot use the default template'),
-  author: z.string().nullable().default(null),
-  recipeTime: z.string().nullable().default(null),
+  author: z
+    .string()
+    .nullable()
+    .default(null)
+    .transform((str) => (str === '' ? null : str)),
+  recipeTime: z
+    .string()
+    .nullable()
+    .default(null)
+    .transform((str) => (str === '' ? null : str)),
   imageFileList: z
     .unknown()
     .transform((value) => value as FileList | null)
@@ -51,10 +59,12 @@ export const recipeFormSchema = z.object({
   cropCoordinates: z
     .string()
     .nullable()
+    .transform((str) => (str === '' ? null : str))
     .refine((str) => str === null || isValidCropCoordinate(str)),
   tags: z
     .string()
     .nullable()
+    .transform((str) => (str === '' ? null : str))
     .refine((str) => str === null || isValidJsonArray(str)),
 });
 


### PR DESCRIPTION
Closes #155 

Optional form values start as null, but for some values we try to parse them on validation, which means validation fails if they become empty strings. Focusing a field turns it from null to empty. In this case, I think we just want to treat empty strings as null values. I also changed this for form fields that can tolerate being empty strings because I think it's nicer if the database has a consistent representation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form field handling to correctly process empty inputs as missing data, ensuring recipe submissions handle optional fields more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->