### PR TITLE
fix: require image file list to be a FileList

### DIFF
--- a/lib/translation/schema.ts
+++ b/lib/translation/schema.ts
@@ -18,8 +18,6 @@ const isValidJsonArray = (str: string) => {
   }
 };
 
-const fileList = z.instanceof(FileList);
-
 const Integer = z.number().transform(Math.floor);
 
 export const cropCoordinateSchema = z.object({
@@ -53,16 +51,9 @@ export const recipeFormSchema = z.object({
     .transform((str) => (str === '' ? null : str)),
   imageFileList: z
     .unknown()
-    .transform((value) => {
-      const { data, success } = z.instanceof(FileList).safeParse(value);
-      // We only accept one file here, but if there is more than one it
-      // is helpful to show a more specific error instead of just nulling
-      // the field out
-      if (success && data.length > 0) {
-        return data;
-      }
-      return null;
-    })
+    // We can't use `FileList` directly here because it's browser-only. For
+    // length 0 FileLists, we deliberately fall back to `null`
+    .transform((value) => ((value as any)?.length ? (value as FileList) : null))
     .refine(
       (fl) => fl === null || fl.length === 1,
       'Upload a maximum of one image'

--- a/lib/translation/schema.ts
+++ b/lib/translation/schema.ts
@@ -18,6 +18,8 @@ const isValidJsonArray = (str: string) => {
   }
 };
 
+const fileList = z.instanceof(FileList);
+
 const Integer = z.number().transform(Math.floor);
 
 export const cropCoordinateSchema = z.object({
@@ -51,7 +53,16 @@ export const recipeFormSchema = z.object({
     .transform((str) => (str === '' ? null : str)),
   imageFileList: z
     .unknown()
-    .transform((value) => value as FileList | null)
+    .transform((value) => {
+      const { data, success } = z.instanceof(FileList).safeParse(value);
+      // We only accept one file here, but if there is more than one it
+      // is helpful to show a more specific error instead of just nulling
+      // the field out
+      if (success && data.length > 0) {
+        return data;
+      }
+      return null;
+    })
     .refine(
       (fl) => fl === null || fl.length === 1,
       'Upload a maximum of one image'


### PR DESCRIPTION
Missed in the last validation fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image file validation for recipe forms to ensure uploaded files are properly validated and at least one file is present before processing. Invalid or empty file uploads are now handled more robustly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->