### PR TITLE
fix(image-upload): seed crop coordinates on image load

### DIFF
--- a/components/image-editor/image-editor-form.client.tsx
+++ b/components/image-editor/image-editor-form.client.tsx
@@ -82,6 +82,11 @@ const ImageEditorForm = (props: ImageEditorFormProps) => {
       height
     );
     setCrop(crop);
+    // react-image-crop only fires onComplete on user interaction, so seed the
+    // crop coordinates from this initial centered crop. Without this, a user who
+    // submits without dragging the crop box leaves cropCoordinates null, the
+    // client-side resize is skipped, and the original full-size file is uploaded.
+    props.onChange(scaleCrop(crop as PercentCrop, { w: width, h: height }));
   };
 
   return (


### PR DESCRIPTION
## Problem

Image uploads were still being rejected for exceeding the request body size limit on the **edit** route (and the create route was vulnerable to the same path).

The client-side resize only ran when `cropCoordinates` was set, and those were only populated by react-image-crop's `onComplete`, which fires on **user interaction**. `onImageLoad` set the crop but never reported it. So a user who selected an image and submitted *without dragging the crop box* left `cropCoordinates` null → the resize was skipped → `recipeToFormData` fell back to uploading the **original full-size file** → size rejection.

Create and edit share the same `RecipeForm` and image editor, so this was never edit-specific — it just surfaced there in practice.

## Fix

Seed `cropCoordinates` from the initial centered crop in `onImageLoad`, so a valid crop always exists and the resize always runs — even with no user interaction.

## Not in this PR

There's a second, separate issue: a cropped+resized 1920×1080 image of a detailed photo can still land in the 1–2MB window and trip the Server Action body limit. The right fix is moving image bytes off the Server Action entirely (presigned direct-to-B2 uploads), which is being tackled as its own follow-up rather than by raising `bodySizeLimit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image editor initialization by ensuring crop coordinates are properly set when an image is loaded. This resolves an issue where users could not submit the form without manually adjusting the crop area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->