### PR TITLE
chore: temporily increase body size limit

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,12 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  experimental: {
+    serverActions: {
+      // TODO: remove this after switching to presigned URLs
+      // for image uploads
+      bodySizeLimit: '3mb',
+    },
+  },
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
The body size limit for server actions is causing occasional issues with image uploads. I think the right fix is to use presigned URLs and avoid sending the images via server action in the first place. But to unblock image uploads now, this PR temporarily increases the body size limit.